### PR TITLE
Throw IOE for Maybe<T>.GetHashCode

### DIFF
--- a/wimm.Secundatives.UnitTests/Maybe_Test.cs
+++ b/wimm.Secundatives.UnitTests/Maybe_Test.cs
@@ -287,5 +287,13 @@ namespace wimm.Secundatives.UnitTests
 
             Assert.False(underTest != other);
         }
+
+        [Fact]
+        public void GetHashCode_Always_Throws()
+        {
+            var underTest = new Maybe<int>(42);
+
+            Assert.Throws<InvalidOperationException>(() => underTest.GetHashCode());
+        }
     }
 }

--- a/wimm.Secundatives.UnitTests/Maybe_Test.cs
+++ b/wimm.Secundatives.UnitTests/Maybe_Test.cs
@@ -289,7 +289,15 @@ namespace wimm.Secundatives.UnitTests
         }
 
         [Fact]
-        public void GetHashCode_Always_Throws()
+        public void GetHashCode_NoneMaybe_Throws()
+        {
+            var underTest = new Maybe<int>();
+
+            Assert.Throws<InvalidOperationException>(() => underTest.GetHashCode());
+        }
+
+        [Fact]
+        public void GetHashCode_ValueMaybe_Throws()
         {
             var underTest = new Maybe<int>(42);
 

--- a/wimm.Secundatives/Maybe.cs
+++ b/wimm.Secundatives/Maybe.cs
@@ -56,12 +56,20 @@ namespace wimm.Secundatives
 
         public bool Equals(Maybe<T> other)
         {
-            var interim = EqualityComparer<T>.Default.Equals(other._value);
-
             return other._exists == _exists
                 && EqualityComparer<T>.Default.Equals(_value, other._value);
         }
 
-        public override int GetHashCode() => throw new NotImplementedException();
+        /// <summary>
+        /// NOT SUPPORTED. <see cref="Maybe{T}"/> represents the possibility of a value. Operations
+        /// that require this method should only be perfomed on data that definitely exists. Use
+        /// <typeparamref name="T"/> directly in these cases.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// <see cref="GetHashCode"/> is called.
+        /// </exception>
+        public override int GetHashCode() =>
+            throw new InvalidOperationException(
+                $"Use the {nameof(T)} type directly for data that requires GetHashCode.");
     }
 }


### PR DESCRIPTION
- Throws IOE instead of NIE for Maybe<T>.GetHashCode. Also adds docs
explaining the behaviour and reasoning.

- Removes unused variable from Maybe<T>.Equals method.

+semver:major
closes #1 