### PR TITLE
Feature/maybe extensions

### DIFF
--- a/wimm.Secundatives.UnitTests/Extensions/Expect_Test.cs
+++ b/wimm.Secundatives.UnitTests/Extensions/Expect_Test.cs
@@ -42,7 +42,7 @@ namespace wimm.Secundatives.UnitTests.Extensions
         public void ExpectNoMessage_DoesNotExist_Throws()
         {
             var underTest = new Maybe<string>();
-            var ex = Assert.Throws<ExpectException>(() => underTest.Expect(_message));
+            var ex = Assert.Throws<ExpectException>(() => underTest.Expect());
         }
 
         [Fact]

--- a/wimm.Secundatives.UnitTests/Extensions/Expect_Test.cs
+++ b/wimm.Secundatives.UnitTests/Extensions/Expect_Test.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using wimm.Secundatives.Exceptions;
+using wimm.Secundatives.Extensions;
+using Xunit;
+
+namespace wimm.Secundatives.UnitTests.Extensions
+{
+    public class Expect_Test
+    {
+        private const string _valid = "doot";
+        const string _message = "this is a message";
+
+        [Fact]
+        public void ExpectMessage_NullMessage_Throws()
+        {
+            var underTest = new Maybe<string>(_valid);
+            Assert.Throws<ArgumentNullException>("message",() => underTest.Expect(null));
+        }
+
+        [Fact]
+        public void ExpectMessage_WhiteSpaceMessage_Throws()
+        {
+            var underTest = new Maybe<string>(_valid);
+            Assert.Throws<ArgumentException>("message",() => underTest.Expect(" \t\r\n"));
+        }
+
+
+        [Fact]
+        public void ExpectMessage_DoesNotExist_ThrowsWithMessage()
+        {
+            var underTest = new Maybe<string>();
+            var ex = Assert.Throws<ExpectException>(() => underTest.Expect(_message));
+
+            Assert.Equal(_message, ex.Message);
+        }
+
+        [Fact]
+        public void ExpectNoMessage_DoesNotExist_Throws()
+        {
+            var underTest = new Maybe<string>();
+            var ex = Assert.Throws<ExpectException>(() => underTest.Expect(_message));
+        }
+
+        [Fact]
+        public void ExpectMessage_Exists_ReturnsValue()
+        {
+            var underTest = new Maybe<string>(_valid);
+            Assert.Equal(_valid, underTest.Expect(_message));
+        }
+
+        [Fact]
+        public void ExpectNoMessage_Exists_ReturnsValue()
+        {
+            var underTest = new Maybe<string>(_valid);
+            Assert.Equal(_valid, underTest.Expect());
+        }
+
+
+    }
+}

--- a/wimm.Secundatives.UnitTests/Extensions/Expect_Test.cs
+++ b/wimm.Secundatives.UnitTests/Extensions/Expect_Test.cs
@@ -12,7 +12,7 @@ namespace wimm.Secundatives.UnitTests.Extensions
     public class Expect_Test
     {
         private const string _valid = "doot";
-        const string _message = "this is a message";
+        private const string _message = "this is a message";
 
         [Fact]
         public void ExpectMessage_NullMessage_Throws()

--- a/wimm.Secundatives.UnitTests/Extensions/UnwrapOr_Test.cs
+++ b/wimm.Secundatives.UnitTests/Extensions/UnwrapOr_Test.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using wimm.Secundatives.Extensions;
+using Xunit;
+
+namespace wimm.Secundatives.UnitTests.Extensions
+{
+    public class UnwrapOr_Test
+    {
+        private const string _valid = "doot";
+        private const string _default = "tood";
+        private Func<string> _defaultFunc = () => _default;
+
+        [Fact]
+        public void UnwrapOr_Value_ReturnsValue()
+        {
+            var underTest = new Maybe<string>(_valid);
+
+            Assert.Equal(_valid, underTest.UnwrapOr(_default));
+        }
+
+        [Fact]
+        public void UnwrapOrFunc_Value_ReturnsValue()
+        {
+            var underTest = new Maybe<string>(_valid);
+            Assert.Equal(_valid, underTest.UnwrapOr(_defaultFunc));
+        }
+
+        [Fact]
+        public void UnwrawpOrFunc_NoValue_ExecutesFunction()
+        {
+            var underTest = new Maybe<string>();
+            Assert.Equal(_default, underTest.UnwrapOr(_defaultFunc));
+        }
+
+
+        [Fact]
+        public void UnwrapOr_NoValue_ReturnsDefaultParam()
+        {
+            var underTest = new Maybe<string>();
+            Assert.Equal(_default, underTest.UnwrapOr(_default));
+        }
+    }
+}

--- a/wimm.Secundatives/Exceptions/ExpectException.cs
+++ b/wimm.Secundatives/Exceptions/ExpectException.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace wimm.Secundatives.Exceptions
+{
+    public class ExpectException : Exception
+    {
+
+        public ExpectException(string message) : base(message)
+        {
+        }
+    }
+}

--- a/wimm.Secundatives/Extensions/MaybeExtensions.cs
+++ b/wimm.Secundatives/Extensions/MaybeExtensions.cs
@@ -21,10 +21,7 @@ namespace wimm.Secundatives.Extensions
         /// <param name="maybe"> The <see cref="Maybe{T}"/> to be inspected </param>
         /// <exception cref="ExpectException"> <paramref name="maybe"/> contains no value </exception>
         /// <returns> The <typeparamref name="T"/> held within <paramref name="maybe"/> if it exists. </returns>
-        public static T Expect<T>(this Maybe<T> maybe)
-        {
-            return maybe.Expect($"Expected value in {nameof(Maybe<T>)}");
-        }
+        public static T Expect<T>(this Maybe<T> maybe) => maybe.Expect($"Expected value in {nameof(Maybe<T>)}");
 
 
         /// Extension to indicate that a value missing from a <see cref="Maybe{T}"/> is unrecoverable. 
@@ -56,14 +53,11 @@ namespace wimm.Secundatives.Extensions
         /// possible </param>
         /// <returns> The <typeparamref name="T"/> held within <paramref name="maybe"/> if it exists. Otherwise
         /// <paramref name="defaultValue"/> </returns>
-        public static T UnwrapOr<T>(this Maybe<T> maybe, T defaultValue)
-        {
-            return maybe.Exists ? maybe.Value : defaultValue;
-        }
+        public static T UnwrapOr<T>(this Maybe<T> maybe, T defaultValue) => maybe.Exists ? maybe.Value : defaultValue;
 
 
         /// <summary>
-        /// Unwraps the <see cref="Maybe{T}"/> if possible and returns a provided default otherwise
+        /// Unwraps the <see cref="Maybe{T}"/> if possible and returns a the results of a provided function otherwise
         /// </summary>
         /// <typeparam name="T"> The type of value contained with the <paramref name="maybe"/> </typeparam>
         /// <param name="maybe"> The <see cref="Maybe{T}"/> to be unwrapped </param>
@@ -71,9 +65,7 @@ namespace wimm.Secundatives.Extensions
         /// unwrapping of <paramref name="maybe"/> is not possible </param>
         /// <returns> The <typeparamref name="T"/> held within <paramref name="maybe"/> if it exists. Otherwise
         /// the result of calling <paramref name="func"/> </returns>
-        public static T UnwrapOr<T>(this Maybe<T> maybe, Func<T> func)
-        {
-            return maybe.Exists ? maybe.Value : func();
-        }
+        public static T UnwrapOr<T>(this Maybe<T> maybe, Func<T> func) => maybe.Exists ? maybe.Value : func();
+
     }
 }

--- a/wimm.Secundatives/Extensions/MaybeExtensions.cs
+++ b/wimm.Secundatives/Extensions/MaybeExtensions.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using wimm.Secundatives.Exceptions;
+
+namespace wimm.Secundatives.Extensions
+{
+    public static class MaybeExtensions
+    {
+        public static T Expect<T>(this Maybe<T> maybe)
+        {
+            return maybe.Expect($"Expected value in {nameof(Maybe<T>)}");
+        }
+
+        public static T Expect<T>(this Maybe<T> maybe, string message)
+        {
+            if (message == null)
+                throw new ArgumentNullException(nameof(message));
+            if (string.IsNullOrWhiteSpace(message))
+                throw new ArgumentException("Parameter must not be whitespace or empty", nameof(message));
+
+            return maybe.Exists ? maybe.Value : throw new ExpectException(message);
+        }
+
+        public static T UnwrapOr<T>(this Maybe<T> maybe, T defaultValue)
+        {
+            return maybe.Exists ? maybe.Value : defaultValue;
+        }
+
+        public static T UnwrapOr<T>(this Maybe<T> maybe, Func<T> func)
+        {
+            return maybe.Exists ? maybe.Value : func();
+        }
+    }
+}

--- a/wimm.Secundatives/Extensions/MaybeExtensions.cs
+++ b/wimm.Secundatives/Extensions/MaybeExtensions.cs
@@ -7,13 +7,35 @@ using wimm.Secundatives.Exceptions;
 
 namespace wimm.Secundatives.Extensions
 {
+    /// <summary>
+    /// Extensions to make working with <see cref="Maybe{T}"/> simpler and improve ergonomics
+    /// </summary>
     public static class MaybeExtensions
     {
+
+        /// <summary>
+        /// Extension to indicate that a value missing from a <see cref="Maybe{T}"/> is unrecoverable. 
+        /// Unwraps the <see cref="Maybe{T}"/> if it exists or throws a <see cref="ExpectException"/>
+        /// </summary>
+        /// <typeparam name="T"> The type of value contained with the <paramref name="maybe"/> </typeparam>
+        /// <param name="maybe"> The <see cref="Maybe{T}"/> to be inspected </param>
+        /// <exception cref="ExpectException"> <paramref name="maybe"/> contains no value </exception>
+        /// <returns> The <typeparamref name="T"/> held within <paramref name="maybe"/> if it exists. </returns>
         public static T Expect<T>(this Maybe<T> maybe)
         {
             return maybe.Expect($"Expected value in {nameof(Maybe<T>)}");
         }
 
+
+        /// Extension to indicate that a value missing from a <see cref="Maybe{T}"/> is unrecoverable. 
+        /// Unwraps the <see cref="Maybe{T}"/> if it exists or throws a <see cref="ExpectException"/>
+        /// with a custom message.
+        /// <typeparam name="T"> The type of value contained with the <paramref name="maybe"/> </typeparam>
+        /// <param name="maybe"> The <see cref="Maybe{T}"/> to be inspected </param>
+        /// <param name="message"> The message to be contained in the thrown <see cref="ExpectException"/> 
+        /// if <paramref name="maybe"/> contains no value </param>
+        /// <exception cref="ExpectException"> <paramref name="maybe"/> contains no value </exception>
+        /// <returns> The <typeparamref name="T"/> held within <paramref name="maybe"/> if it exists. </returns>
         public static T Expect<T>(this Maybe<T> maybe, string message)
         {
             if (message == null)
@@ -24,11 +46,31 @@ namespace wimm.Secundatives.Extensions
             return maybe.Exists ? maybe.Value : throw new ExpectException(message);
         }
 
+
+        /// <summary>
+        /// Unwraps the <see cref="Maybe{T}"/> if possible and returns a provided default otherwise
+        /// </summary>
+        /// <typeparam name="T"> The type of value contained with the <paramref name="maybe"/> </typeparam>
+        /// <param name="maybe"> The <see cref="Maybe{T}"/> to be unwrapped </param>
+        /// <param name="defaultValue"> An instance of <typeparamref name="T"/> to be returned if unwrapping is not 
+        /// possible </param>
+        /// <returns> The <typeparamref name="T"/> held within <paramref name="maybe"/> if it exists. Otherwise
+        /// <paramref name="defaultValue"/> </returns>
         public static T UnwrapOr<T>(this Maybe<T> maybe, T defaultValue)
         {
             return maybe.Exists ? maybe.Value : defaultValue;
         }
 
+
+        /// <summary>
+        /// Unwraps the <see cref="Maybe{T}"/> if possible and returns a provided default otherwise
+        /// </summary>
+        /// <typeparam name="T"> The type of value contained with the <paramref name="maybe"/> </typeparam>
+        /// <param name="maybe"> The <see cref="Maybe{T}"/> to be unwrapped </param>
+        /// <param name="func"> A function that returns a <typeparamref name="T"/> that will be called if
+        /// unwrapping of <paramref name="maybe"/> is not possible </param>
+        /// <returns> The <typeparamref name="T"/> held within <paramref name="maybe"/> if it exists. Otherwise
+        /// the result of calling <paramref name="func"/> </returns>
         public static T UnwrapOr<T>(this Maybe<T> maybe, Func<T> func)
         {
             return maybe.Exists ? maybe.Value : func();


### PR DESCRIPTION
Created MaybeExtensions, a set of extensions to make the ergonomics of working with Maybe<T> better. The names are taken from Rust's option type because I think they did a great job with the names.

Expect -  Extension to indicate that a value missing from a Maybe is unrecoverable. Unwraps the input maybe if it exists or throws an ExpectException with an optional custom message.

UnwrapOr - Unwraps the input Maybe if possible or provides a constant value or the result of evaluating a Func<T> if no value exists.