### PR TITLE
Feature/errors

### DIFF
--- a/wimm.Secundatives.UnitTests/Error_Test.cs
+++ b/wimm.Secundatives.UnitTests/Error_Test.cs
@@ -1,13 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace wimm.Secundatives.UnitTests
 {
-    
+
     public class Error_Test
     {
         [Fact]

--- a/wimm.Secundatives.UnitTests/Error_Test.cs
+++ b/wimm.Secundatives.UnitTests/Error_Test.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace wimm.Secundatives.UnitTests
+{
+    
+    public class Error_Test
+    {
+        [Fact]
+        public void Construct_MessageNull_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => new Error(null));
+        }
+
+        [Fact]
+        public void Construct_MessageWhitespace_Throws()
+        {
+            TestHelpers.AssertThrowsIfWhitespace(x => new Error(x));
+        }
+
+        [Fact]
+        public void Construct_MessageValid_Constructs()
+        {
+            var err = new Error("I am a detailed error message: doot failed to construct");
+            Assert.NotNull(err.Message);
+        }
+    }
+}

--- a/wimm.Secundatives.UnitTests/TestHelpers.cs
+++ b/wimm.Secundatives.UnitTests/TestHelpers.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace wimm.Secundatives.UnitTests
+{
+    public class TestHelpers
+    {
+        private static readonly List<string> _stringControls = new List<string> { "\t", "\r", "\n", " "};
+
+
+        public static void AssertThrowsIfWhitespace(Action<string> action)
+        {
+            foreach (var control in _stringControls)
+            {
+                Assert.Throws<ArgumentException>(() => action(control));
+            }
+        }
+    }
+}

--- a/wimm.Secundatives/Error.cs
+++ b/wimm.Secundatives/Error.cs
@@ -1,10 +1,12 @@
 ﻿using System;
+using System.Diagnostics;
 
 namespace wimm.Secundatives
 {
     /// <summary>
     /// Base class for Error types to be returned from results. 
     /// </summary>
+    [DebuggerDisplay("{Message}")]
     public class Error
     {
         /// <summary>
@@ -28,5 +30,14 @@ namespace wimm.Secundatives
         /// A detailed, non-null message describing the error. 
         /// </summary>
         public string Message { get; }
+
+        /// <summary>
+        /// Converts the <see cref="Error"/> into a <see cref="string"/>. 
+        /// </summary>
+        /// <returns> The formatted error message </returns>
+        public override sealed string ToString()
+        {
+            return Message;
+        }
     }
 }

--- a/wimm.Secundatives/Error.cs
+++ b/wimm.Secundatives/Error.cs
@@ -10,7 +10,9 @@ namespace wimm.Secundatives
         /// <summary>
         /// Constructs a new instance of <see cref="Error"/> with the specified message
         /// </summary>
-        /// <param name="message"></param>
+        /// <param name="message"> The message to be included with the error </param>
+        /// <exception cref="ArgumentNullException"> <paramref name="message"/> is null </exception>
+        /// <exception cref="ArgumentException"> <paramref name="message"/> is whitespace </exception>
         public Error(string message)
         {
             if (message == null)

--- a/wimm.Secundatives/Error.cs
+++ b/wimm.Secundatives/Error.cs
@@ -1,0 +1,30 @@
+﻿using System;
+
+namespace wimm.Secundatives
+{
+    /// <summary>
+    /// Base class for Error types to be returned from results. 
+    /// </summary>
+    public class Error
+    {
+        /// <summary>
+        /// Constructs a new instance of <see cref="Error"/> with the specified message
+        /// </summary>
+        /// <param name="message"></param>
+        public Error(string message)
+        {
+            if (message == null)
+                throw new ArgumentNullException(nameof(message));
+            if (string.IsNullOrWhiteSpace(message))
+                throw new ArgumentException(
+                    "Error message must contain one or more non-whitespace characters", nameof(message));
+
+            Message = message;
+        }
+
+        /// <summary>
+        /// A detailed, non-null message describing the error. 
+        /// </summary>
+        public string Message { get; }
+    }
+}


### PR DESCRIPTION
Added the Error class to act as a very lean base class for Result<T>. 

The reason I went with Error instead of Exceptions is that exceptions are generally a bit heavier and come with a bunch more guarantees and parameters (StackTrace etc). Given that the entire point of the result type is going to be just to communicate errors I didn't want to have to bring a lot of the baggage associated with exceptions through. I'm sure that I'll create an error type that wraps an exception eventually but I don't want to conflate the two off the bat. More philosophical than anything else. 

I went with the base class over an interface specifically because of the lack of functionality and because I wanted to build in the checks for consistency so that consumers are always going to be sure that at the very least the base level property guarantees are met. 