### PR TITLE
Feature/variant

### DIFF
--- a/wimm.Secundatives.UnitTests/Extensions/UnwrapOr_Test.cs
+++ b/wimm.Secundatives.UnitTests/Extensions/UnwrapOr_Test.cs
@@ -12,7 +12,7 @@ namespace wimm.Secundatives.UnitTests.Extensions
     {
         private const string _valid = "doot";
         private const string _default = "tood";
-        private Func<string> _defaultFunc = () => _default;
+        private readonly Func<string> _defaultFunc = () => _default;
 
         [Fact]
         public void UnwrapOr_Value_ReturnsValue()

--- a/wimm.Secundatives.UnitTests/Variant_Test.cs
+++ b/wimm.Secundatives.UnitTests/Variant_Test.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using Xunit;
+
+namespace wimm.Secundatives.UnitTests
+{
+    public class Variant_Test
+    {
+        private const string _testString = "doot";
+
+        [Fact]
+        public void GetString_ContainsInt_Throws()
+        {
+            var underTest = ConstructInt();
+            Assert.Throws<InvalidOperationException>(() => underTest.Get<string>());
+        }
+
+        [Fact]
+        public void IsBase_ContainsDerived_ReturnsTrue()
+        {
+            var underTest = new Variant<string, A>();
+        }
+
+
+        [Fact]
+        public void GetString_ContainsString_ReturnsString()
+        {
+            var underTest = ConstructString();
+            Assert.Equal(_testString, underTest.Get<string>());
+        }
+        
+        [Fact]
+        public void IsString_ContainsString_ReturnsTrue()
+        {
+            var underTest = ConstructString();
+            Assert.True(underTest.Is<string>());
+        }
+
+        [Fact]
+        public void IsString_ContainsInt_ReturnsFalse()
+        {
+            var underTest = ConstructInt();
+            Assert.False(underTest.Is<string>());
+        }
+
+        [Fact]
+        public void Construct_ValidValue_ConstructsWithValue()
+        {
+            var stringVariant = new Variant<int, string>("doot");
+            Assert.True(stringVariant.Is<string>());
+
+            var intVariant = new Variant<int, string>(16);
+            Assert.True(intVariant.Is<int>());
+        }
+
+        private Variant<int, string> ConstructString()
+        {
+            return new Variant<int, string>(_testString);
+        }
+
+        private Variant<int, string> ConstructInt()
+        {
+            return new Variant<int, string>(42);
+        }
+
+        class A { }
+        class B : A { }
+    }
+}

--- a/wimm.Secundatives.UnitTests/Variant_Test.cs
+++ b/wimm.Secundatives.UnitTests/Variant_Test.cs
@@ -17,7 +17,8 @@ namespace wimm.Secundatives.UnitTests
         [Fact]
         public void IsBase_ContainsDerived_ReturnsTrue()
         {
-            var underTest = new Variant<string, A>();
+            var underTest = new Variant<string, B>(new B());
+            Assert.True(underTest.Is<A>());
         }
 
 

--- a/wimm.Secundatives.UnitTests/Variant_Test.cs
+++ b/wimm.Secundatives.UnitTests/Variant_Test.cs
@@ -8,6 +8,15 @@ namespace wimm.Secundatives.UnitTests
         private const string _testString = "doot";
 
         [Fact]
+        public void GetLong_LongNotTypeParam_Throws()
+        {
+            var underTest = ConstructInt();
+            Assert.Throws<NotSupportedException>(() => underTest.Is<long>());
+        }
+
+
+
+        [Fact]
         public void GetString_ContainsInt_Throws()
         {
             var underTest = ConstructInt();
@@ -19,6 +28,13 @@ namespace wimm.Secundatives.UnitTests
         {
             var underTest = new Variant<string, B>(new B());
             Assert.True(underTest.Is<A>());
+        }
+
+        [Fact]
+        public void IsDerived_ContainsBase_Throws()
+        {
+            var underTest = new Variant<string, A>(new A());
+            Assert.Throws<NotSupportedException>(() => underTest.Get<B>());
         }
 
 

--- a/wimm.Secundatives.UnitTests/Variant_Test.cs
+++ b/wimm.Secundatives.UnitTests/Variant_Test.cs
@@ -26,7 +26,7 @@ namespace wimm.Secundatives.UnitTests
         [Fact]
         public void IsBase_ContainsDerived_ReturnsTrue()
         {
-            var underTest = new Variant<string, B>(new B());
+            var underTest = new Variant<string, A>(new B());
             Assert.True(underTest.Is<A>());
         }
 

--- a/wimm.Secundatives/Variant.cs
+++ b/wimm.Secundatives/Variant.cs
@@ -35,20 +35,16 @@ namespace wimm.Secundatives
         /// <typeparam name="W"> The type to test for </typeparam>
         /// <returns>Returns true if the internal value is the same as <typeparamref name="W"/></returns>
         /// <exception cref="NotSupportedException"> 
-        /// <typeparamref name="W"/> is not one of or is not a superclass of 
-        /// <typeparamref name="T"/> or <typeparamref name="U"/>
+        /// <typeparamref name="W"/> is not one of <typeparamref name="T"/> or <typeparamref name="U"/>
         /// </exception>
         public bool Is<W>()
         {
-            if (_value is W)
-                return true;
-
             var wType = typeof(W);
 
-            if (IsMemberTypeOrSuperType(wType))
-                return false;
+            if (!IsMemberType(wType))
+                throw UnsupportedType(wType, new List<Type> { typeof(T), typeof(U) });
 
-            throw UnsupportedType(wType, new List<Type> { typeof(T), typeof(U) });
+            return _value is W;
         }
 
 
@@ -61,8 +57,7 @@ namespace wimm.Secundatives
         /// <typeparamref name="W"/>
         /// </exception>
         /// <exception cref="NotSupportedException"> 
-        /// <typeparamref name="W"/> is not one of or is not a superclass of 
-        /// <typeparamref name="T"/> or <typeparamref name="U"/>
+        /// <typeparamref name="W"/> is not one of <typeparamref name="T"/> or <typeparamref name="U"/>
         /// </exception>
         public W Get<W>() => Is<W>() ? (W)_value : throw BadType(typeof(W), _value.GetType());
 
@@ -87,20 +82,10 @@ namespace wimm.Secundatives
         public static implicit operator Variant<T, U>(T val) => new Variant<T, U>(val);
         public static implicit operator Variant<T, U>(U val) => new Variant<T, U>(val);
 
-        private bool IsSuperclassOfMemberType(Type type)
-        {
-            return typeof(T).IsSubclassOf(type) || typeof(U).IsSubclassOf(type);
-
-        }
 
         private bool IsMemberType(Type type)
         {
             return type == typeof(U) || type == typeof(T);
-        }
-
-        private bool IsMemberTypeOrSuperType(Type type)
-        {
-            return IsMemberType(type) || IsSuperclassOfMemberType(type);
         }
 
         private static InvalidOperationException BadType(Type expected, Type recieved)

--- a/wimm.Secundatives/Variant.cs
+++ b/wimm.Secundatives/Variant.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace wimm.Secundatives
+{
+    /// <summary>
+    /// A typesafe union that contains either a <typeparamref name="T"/> or a <typeparamref name="U"/>
+    /// </summary>
+    public struct Variant<T, U>
+    {
+        /// <summary>
+        /// Ensures that <typeparamref name="U"/> and <typeparamref name="T"/> are not within the same
+        /// inheritance heirarchy
+        /// </summary>
+        static Variant()
+        {
+            var uType = typeof(U);
+            var tType = typeof(T);
+
+            if (tType.IsSubclassOf(uType) || uType.IsSubclassOf(tType) )
+            {
+                //TODO:CN -- Maybe fix? Maybe not?
+                throw new NotSupportedException(
+                    "Cannot create a variant of two classess within the same inheritance heirarchy");
+            }
+        }
+
+        //Mike Tyson
+        private readonly object _value;
+
+        /// <summary>
+        /// Checks the type of the type param against the type of the internal member
+        /// </summary>
+        /// <typeparam name="W"> The type to test for </typeparam>
+        /// <returns>Returns true if the internal value is the same as <typeparamref name="W"/></returns>
+        /// <remarks> There is no point calling this method with a value of <typeparamref name="W"/> that 
+        /// is not either <typeparamref name="T"/> or <typeparamref name="U"/> 
+        /// </remarks>
+        public bool Is<W>() => _value is W;
+
+        /// <summary>
+        /// Gets a value of type <typeparamref name="W"/> if possible. 
+        /// </summary>
+        /// <typeparam name="W"> The type to attempt to retrieve from the <see cref="Variant{T, U}"/> </typeparam>
+        /// <returns> A value of type <typeparamref name="W"/> if it exists </returns>
+        /// <exception cref="InvalidOperationException"> The variant's value is not of type 
+        /// <typeparamref name="W"/>
+        /// </exception>
+        /// /// <remarks> There is no point calling this method with a value of <typeparamref name="W"/> that 
+        /// is not either <typeparamref name="T"/> or <typeparamref name="U"/> 
+        /// </remarks>
+        public W Get<W>() => Is<W>() ? (W)_value : throw BadType(typeof(W), _value.GetType());
+
+        /// <summary>
+        /// Constructs a <see cref="Variant{T, U}"/> from a value of <typeparamref name="T"/>
+        /// </summary>
+        /// <param name="value"> The value to store </param>
+        public Variant(T value)
+        {
+            _value = value;
+        }
+
+        /// <summary>
+        /// Constructs a <see cref="Variant{T, U}"/> from a value of <typeparamref name="U"/>
+        /// </summary>
+        /// <param name="value"> The value to store </param>
+        public Variant(U value)
+        {
+            _value = value;
+        }
+        
+        public static implicit operator Variant<T, U>(T val) => new Variant<T, U>(val);
+        public static implicit operator Variant<T, U>(U val) => new Variant<T, U>(val);
+
+        private static InvalidOperationException BadType(Type expected, Type recieved)
+        {
+            return new InvalidOperationException(
+                $"Variant conversion to uncontained type:\nRequested: {expected}\nGot: {recieved}");
+        }
+    }
+
+
+}

--- a/wimm.Secundatives/Variant.cs
+++ b/wimm.Secundatives/Variant.cs
@@ -6,7 +6,7 @@ namespace wimm.Secundatives
     /// <summary>
     /// A typesafe union that contains either a <typeparamref name="T"/> or a <typeparamref name="U"/>
     /// </summary>
-    public struct Variant<T, U>
+    public class Variant<T, U>
     {
         /// <summary>
         /// Ensures that <typeparamref name="U"/> and <typeparamref name="T"/> are not within the same

--- a/wimm.Secundatives/Variant.cs
+++ b/wimm.Secundatives/Variant.cs
@@ -46,7 +46,7 @@ namespace wimm.Secundatives
         /// <exception cref="InvalidOperationException"> The variant's value is not of type 
         /// <typeparamref name="W"/>
         /// </exception>
-        /// /// <remarks> There is no point calling this method with a value of <typeparamref name="W"/> that 
+        /// <remarks> There is no point calling this method with a value of <typeparamref name="W"/> that 
         /// is not either <typeparamref name="T"/> or <typeparamref name="U"/> 
         /// </remarks>
         public W Get<W>() => Is<W>() ? (W)_value : throw BadType(typeof(W), _value.GetType());

--- a/wimm.Secundatives/Variant.cs
+++ b/wimm.Secundatives/Variant.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 namespace wimm.Secundatives
 {


### PR DESCRIPTION
Initial implementation of a variant type to underpin the result type. 

Typesafe  union that prevents you from pulling out values that don't exist.

Boxing wasn't my favourite solution here but I think it's the one that leads to the cleanest code. Given that C# has relatively limited metaprogramming the alternatives all made me relatively sad. (C++ pair style .First/Second, backing array, etc) So I went with the simplest one that gets the job done and I think it's relatively applicable in a bunch of scenarios I can see hitting in dev