### PR TITLE
Added custom error types for results and changed the inheritance heirarchy

### DIFF
--- a/wimm.Secundatives.UnitTests/Result_Test.cs
+++ b/wimm.Secundatives.UnitTests/Result_Test.cs
@@ -68,12 +68,12 @@ namespace wimm.Secundatives.UnitTests
         
         private Result<int> ConstructInt()
         {
-            return new Result<int>(42);
+            return 42;
         }
 
         private Result<int> ConstructErr()
         {
-            return new Result<int>(_err);
+            return _err;
         }
 
     }

--- a/wimm.Secundatives/Result.cs
+++ b/wimm.Secundatives/Result.cs
@@ -4,17 +4,19 @@ using wimm.Secundatives.Extensions;
 namespace wimm.Secundatives
 {
     /// <summary>
-    /// A basic Result class that handles operations with a possibility of failure
+    /// A result class that handles operations with a possibility of failure need to be able to report the error context
+    /// with a custom error type
     /// </summary>
-    /// <typeparam name="T"> The type to be returned on success </typeparam>
-    public class Result<T> : Variant<T,Error>
+    /// <typeparam name="T"></typeparam>
+    /// <typeparam name="TError"></typeparam>
+    public class Result<T,TError> : Variant<T, TError>
     {
-
-        /// <summary> A value indicating whether the operation ended in error </summary>
-        public bool IsError => Is<Error>();
+        /// <summary> A value indicating whether the operation resulted in an error type </summary>
+        public bool IsError => Is<TError>();
 
         /// <summary> A value indicating if the operation successfully returned a value </summary>
         public bool IsValue => Is<T>();
+
 
         /// <summary> Gets the value contained in the result. </summary>
         /// <exception cref="InvalidOperationException"> The result contains no value - operation failed </exception>
@@ -22,8 +24,35 @@ namespace wimm.Secundatives
 
         /// <summary> Gets the error contained in the result </summary>
         /// <exception cref="InvalidOperationException"> The result contains no error - operation succeeded </exception>
-        public Error Error => Get<Error>();
+        public TError Error => Get<TError>();
 
+        /// <summary>
+        /// Constructs a <see cref="Result{T}"/> from a <typeparamref name="T"/> value
+        /// </summary>
+        /// <param name="value"> A <typeparamref name="T"/> value of the result, indicates success </param>
+        public Result(T value) : base(value)
+        {
+        }
+
+        /// <summary> Constructs a <see cref="Result{T}"/> from an <see cref="Error"/> </summary>
+        /// <param name="err"> The <see cref="TError"/> explaining why the operation was unsucessful </param>
+        public Result(TError err) : base(err)
+        {
+        }
+
+        public static implicit operator Result<T,TError>(T value) => new Result<T,TError>(value);
+        public static implicit operator Result<T, TError>(TError error) => new Result<T, TError>(error);
+    }
+
+
+
+    /// <summary>
+    /// A basic Result class that handles operations with a possibility of failure that uses a special error class to 
+    /// report failure
+    /// </summary>
+    /// <typeparam name="T"> The type to be returned on success </typeparam>
+    public class Result<T> : Result<T,Error>
+    {
 
         /// <summary>
         /// Constructs a <see cref="Result{T}"/> from a <typeparamref name="T"/> value
@@ -38,6 +67,9 @@ namespace wimm.Secundatives
         public Result(Error err) : base(err)
         {
         }
+
+        public static implicit operator Result<T>(T value) => new Result<T>(value);
+        public static implicit operator Result<T>(Error error) => new Result<T>(error);
 
     }
 


### PR DESCRIPTION
+semver:minor

Added Result<T,TError> as the base of Result<T> so that custom error types are available and you don't have to derive an error when you have things like enums etc that already represent what you want. Kept Result<T> as a specific specialization of Result<T,TError> and added implicit result ctors so that you can do things like:

```cs
myCondition ? value : "Thing is on fire" 
```

and other nice improvements (This already exists on the variant base class just not the result type)