### PR TITLE
Create implicit ctor from T -> Maybe<T>

### DIFF
--- a/wimm.Secundatives/Maybe.cs
+++ b/wimm.Secundatives/Maybe.cs
@@ -64,6 +64,8 @@ namespace wimm.Secundatives
                 && EqualityComparer<T>.Default.Equals(_value, other._value);
         }
 
+        public static implicit operator Maybe<T>(T value) => new Maybe<T>(value);
+
         /// <summary>
         /// NOT SUPPORTED. <see cref="Maybe{T}"/> represents the possibility of a value. Operations
         /// that require this method should only be perfomed on data that definitely exists. Use


### PR DESCRIPTION
This seems like a bit of a no brainer. The ability to remove a lot of the new Maybe<T>() is a blessing. Only thing that would be nice would be a nicer way to give None without the full qualification but all the solutions I've thought of so far are exactly as verbose. 