### PR TITLE
Feature/maybe mapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 .vs/
-
 **/[Bb]in/
 **/[Oo]bj/
-\.sonarqube/
-
+.sonarqube/
+.cov
 cov/

--- a/wimm.Secundatives.UnitTests/Extensions/MappingExtensions_Test.cs
+++ b/wimm.Secundatives.UnitTests/Extensions/MappingExtensions_Test.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace wimm.Secundatives.UnitTests.Extensions
+{
+    public class MappingExtensions_Test
+    {
+        [Fact]
+        public void MapMaybe_None_ReturnsNone()
+        {
+            var underTest = Maybe<int>.None;
+            var result = underTest.Map(x => x + 100);
+
+            Assert.Equal(Maybe<int>.None, result);
+        }
+
+        [Fact]
+        public void MapMaybe_Value_ReturnsTransformed()
+        {
+            var underTest = new Maybe<int>(10);
+            var result = underTest.Map(x => x.ToString());
+
+            Assert.Equal("10", result.Value);
+        }
+
+        [Fact]
+        public async Task MapMaybe_NoneAndFuncReturnsTask_ReturnsNoneTask()
+        {
+            var underTest = Maybe<int>.None;
+
+            var result = await underTest.Map(x => Task.FromResult(x.ToString()));
+
+            Assert.Equal(Maybe<string>.None, result);
+        }
+
+        [Fact]
+        public async Task MapMaybe_ValueAndFuncReturnsTask_ReturnsValueTask()
+        {
+            var underTest = new Maybe<int>(10);
+            var result = await underTest.Map(x => Task.FromResult(x.ToString()));
+            
+            Assert.Equal("10", result.Value);
+        }
+
+        [Fact]
+        public void MapMaybe_NoneAndFuncReturnsMaybe_ReturnsNone()
+        {
+            var underTest = Maybe<int>.None;
+            var result = underTest.Map(x => new Maybe<string>((x + 100).ToString()));
+
+            Assert.Equal(Maybe<string>.None, result);
+
+        }
+
+        [Fact]
+        public void MapMaybe_ValueAndFuncReturnsValue_ReturnsValue()
+        {
+            var underTest = new Maybe<int>(100);
+            var result = underTest.Map(x => (x + 100).ToString());
+
+            Assert.Equal("200", result.Value);
+        }
+
+        [Fact]
+        public async Task MapTask_None_ReturnsNone()
+        {
+            var underTest = Task.FromResult(Maybe<int>.None);
+
+            var result = await underTest.Map(x => x.ToString());
+            Assert.Equal(Maybe<string>.None, result);
+        }
+
+        [Fact]
+        public async Task MapTask_Value_ReturnsValue()
+        {
+            var underTest = Task.FromResult(new Maybe<int>(100));
+
+            var result = await underTest.Map(x => x.ToString());
+
+            Assert.Equal("100", result.Value);
+        }
+
+        [Fact]
+        public async Task MapMaybe_NoneAndFuncReturnsAsyncMaybe_ReturnsNoneTask()
+        {
+            var underTest = Maybe<int>.None;
+            var result = await underTest.Map(x => Task.FromResult(new Maybe<string>(x.ToString())));
+
+            Assert.Equal(Maybe<string>.None, result);
+        }
+
+        [Fact]
+        public async Task MapMaybe_ValueAndFuncReturnAsyncValue_ReturnsValueTask()
+        {
+            var underTest = new Maybe<int>(100);
+            var result = await underTest.Map(x => Task.FromResult(new Maybe<string>(x.ToString())));
+            
+            Assert.Equal("100", result.Value);
+        }
+
+    }
+}

--- a/wimm.Secundatives.UnitTests/wimm.Secundatives.UnitTests.csproj
+++ b/wimm.Secundatives.UnitTests/wimm.Secundatives.UnitTests.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.6.3">
+    <PackageReference Include="coverlet.msbuild" Version="2.7.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/wimm.Secundatives/Extensions/MappingExtensions.cs
+++ b/wimm.Secundatives/Extensions/MappingExtensions.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace wimm.Secundatives
+{
+    public static class MappingExtensions
+    {
+
+
+        /// <summary>
+        /// Transforms a <see cref="Maybe{T}"/> into a <see cref="Maybe{U}"/> by applying a function in the case that <paramref name="value"/>
+        /// contains a value or <see cref="Maybe{U}.None"/> if <paramref name="value"/> is <see cref="Maybe{T}.None"/>
+        /// </summary>
+        /// <typeparam name="T"> The type to be mapped from</typeparam>
+        /// <typeparam name="U"> The type to be mapped to </typeparam>
+        /// <param name="value"> A <see cref="Maybe{T}"/> that determines if a transform occurs </param>
+        /// <param name="func"> The function that will transform <paramref name="value"/>'s T</param>
+        /// <returns> A <see cref="Maybe{U}"/> equal to <see cref="Maybe{U}.None"/> if <paramref name="value"/> is none otherwise a 
+        /// <see cref="Maybe{T}"/> containing the result of <paramref name="func"/> being applied to <paramref name="value"/>'s 
+        /// <typeparamref name="T"/>
+        /// </returns>
+        public static Maybe<U> Map<T, U>(this Maybe<T> value, Func<T, U> func)
+        {
+            return value.Exists
+                ? func(value.Value)
+                : Maybe<U>.None;
+        }
+
+        /// <summary>
+        /// Transforms a <see cref="Maybe{T}"/> into a <see cref="Maybe{U}"/> by applying a function in the case that <paramref name="value"/>
+        /// contains a value or <see cref="Maybe{U}.None"/> if <paramref name="value"/> is <see cref="Maybe{T}.None"/>
+        /// </summary>
+        /// <typeparam name="T"> The type to be mapped from</typeparam>
+        /// <typeparam name="U"> The type to be mapped to </typeparam>
+        /// <param name="value"> A <see cref="Maybe{T}"/> that determines if a transform occurs </param>
+        /// <param name="func"> A function that produces the resultant <see cref="Maybe{T}"/></param>
+        /// <returns> A <see cref="Maybe{U}"/> equal to <see cref="Maybe{U}.None"/> if <paramref name="value"/> is none
+        /// otherwise the result of <paramref name="func"/> being applied to <paramref name="value"/>'s <typeparamref name="T"/>
+        /// </returns>
+        public static Maybe<U> Map<T, U>(this Maybe<T> value, Func<T, Maybe<U>> func)
+        {
+            return value.Exists
+                ? func(value.Value)
+                : Maybe<U>.None;
+        }
+
+
+        /// <summary>
+        /// Transforms a <see cref="Task{Maybe{T}}"/> into a <see cref="Task{Maybe{U}}"/> by applying a function in the case that <paramref name="value"/>
+        /// when awaited, contains a value or <see cref="Maybe{U}.None"/> if <paramref name="value"/>'s task results in <see cref="Maybe{T}.None"/>
+        /// </summary>
+        /// <typeparam name="T"> The type to be mapped from</typeparam>
+        /// <typeparam name="U"> The type to be mapped to </typeparam>
+        /// <param name="value"> A <see cref="Task{Maybe{T}}"/> that represents a future value of <typeparamref name="T"/> that when awaited 
+        /// determines if a transform occurs </param>
+        /// <param name="func"> The function that will transform <paramref name="value"/>'s T</param>
+        /// <returns> A <see cref="Task{Maybe{U}}"/> that when awaited will be equal to <see cref="Maybe{U}.None"/> if <paramref name="value"/> is none
+        /// otherwise the result of <paramref name="func"/> being applied to <paramref name="value"/>'s <typeparamref name="T"/>
+        /// </returns>
+        public static async Task<Maybe<U>> Map<T, U>(this Task<Maybe<T>> task, Func<T, U> func)
+        {
+            var value = await task;
+            return value.Map(func);
+        }
+
+
+        /// <summary>
+        /// Transforms a <see cref="Maybe{T}"/> into a <see cref="Task{Maybe{U}}"/> by applying an async function in the case that <paramref name="value"/>
+        /// contains a value or <see cref="Maybe{U}.None"/> if <paramref name="value"/> is <see cref="Maybe{T}.None"/>
+        /// </summary>
+        /// <typeparam name="T"> The type to be mapped from</typeparam>
+        /// <typeparam name="U"> The type to be mapped to </typeparam>
+        /// <param name="value"> A <see cref="Maybe{T}"/> that determines if a transform occurs </param>
+        /// <param name="func"> The async function that will transform <paramref name="value"/>'s T</param>
+        /// <returns> A <see cref="Task{Maybe{U}}"/> that when awaited will be equal to <see cref="Maybe{U}.None"/> if <paramref name="value"/> is none
+        /// otherwise the result of <paramref name="func"/> being applied to <paramref name="value"/>'s <typeparamref name="T"/>
+        /// </returns>
+        public static async Task<Maybe<U>> Map<T, U>(this Maybe<T> value, Func<T, Task<U>> func)
+        {
+            return value.Exists
+                ? await func(value.Value)
+                : Maybe<U>.None;
+        }
+
+
+        /// <summary>
+        /// Transforms a <see cref="Maybe{T}"/> into a <see cref="Task{Maybe{U}}"/> by flattening the return value of an async function applied to the value
+        /// contained in <paramref name="value"/> in the case that <paramref name="value"/> contains a value or <see cref="Maybe{U}.None"/> 
+        /// if <paramref name="value"/> is <see cref="Maybe{T}.None"/> </summary>
+        /// <typeparam name="T"> The type to be mapped from</typeparam>
+        /// <typeparam name="U"> The type to be mapped to </typeparam>
+        /// <param name="value"> A <see cref="Maybe{T}"/> that determines if a transform occurs </param>
+        /// <param name="func"> The async function that will transform <paramref name="value"/>'s T into a <see cref="Maybe{U}"/></param>
+        /// <returns> A <see cref="Task{Maybe{U}}"/> that when awaited will be equal to <see cref="Maybe{U}.None"/> if <paramref name="value"/> is none
+        /// otherwise the result of <paramref name="func"/> being applied to <paramref name="value"/>'s <typeparamref name="T"/>
+        /// </returns>
+        public static async Task<Maybe<U>> Map<T, U>(this Maybe<T> value, Func<T, Task<Maybe<U>>> func)
+        {
+            return value.Exists
+                ? await func(value.Value)
+                : Maybe<U>.None;
+        }
+    }
+}

--- a/wimm.Secundatives/Extensions/MaybeExtensions.cs
+++ b/wimm.Secundatives/Extensions/MaybeExtensions.cs
@@ -156,8 +156,5 @@ namespace wimm.Secundatives.Extensions
         {
             return (await value).AsMaybe();
         }
-
-
-
     }
 }


### PR DESCRIPTION
Created methods for performing transformations on Maybe's without having to worry what they contain. 
closes #34 
ex:
```cs
var myMaybe = thing.FunctionThatReturnsMaybe();

//Normally here I'd have to care/check. Like:
if(!myMaybe.Exists)
   return thing;

var also = DoAThing(myMaybe.Value);

if(!also.Exists)
    return thing;

---
//Instead!
return thing.FunctionThatReturnsMaybe()
    .Map(x => DoAThing(x))
    .UnwrapOr(thing);

//Never have to worry about the none case when manipulating it. 
