### PR TITLE
Implement .Or extension methods for Maybe

### DIFF
--- a/wimm.Secundatives.UnitTests/Extensions/MappingExtensions_Test.cs
+++ b/wimm.Secundatives.UnitTests/Extensions/MappingExtensions_Test.cs
@@ -142,6 +142,5 @@ namespace wimm.Secundatives.UnitTests.Extensions
 
             Assert.Equal(Maybe<string>.None, result);
         }
-
     }
 }

--- a/wimm.Secundatives.UnitTests/Extensions/Or_Test.cs
+++ b/wimm.Secundatives.UnitTests/Extensions/Or_Test.cs
@@ -12,9 +12,7 @@ namespace wimm.Secundatives.UnitTests.Extensions
         [Fact]
         public void Or_MaybeFunc_NeitherMaybeExists_ReturnsNone()
         {
-            Assert.Equal(
-                Maybe<int>.None,
-                Maybe<int>.None.Or(() => Maybe<int>.None));
+            Assert.Equal(Maybe<int>.None, Maybe<int>.None.Or(() => Maybe<int>.None));
         }
 
         [Fact]
@@ -22,9 +20,7 @@ namespace wimm.Secundatives.UnitTests.Extensions
         {
             var expected = new Maybe<int>(42);
 
-            Assert.Equal(
-                expected,
-                Maybe<int>.None.Or(() => expected));
+            Assert.Equal(expected, Maybe<int>.None.Or(() => expected));
         }
 
         [Fact]
@@ -32,9 +28,7 @@ namespace wimm.Secundatives.UnitTests.Extensions
         {
             var expected = new Maybe<int>(42);
 
-            Assert.Equal(
-                expected,
-                expected.Or(() => Maybe<int>.None));
+            Assert.Equal(expected,  expected.Or(() => Maybe<int>.None));
         }
 
         [Fact]
@@ -42,9 +36,7 @@ namespace wimm.Secundatives.UnitTests.Extensions
         {
             var expected = new Maybe<int>(42);
 
-            Assert.Equal(
-                expected,
-                expected.Or(() => new Maybe<int>(43)));
+            Assert.Equal(expected, expected.Or(() => new Maybe<int>(43)));
         }
 
         [Fact]
@@ -53,9 +45,7 @@ namespace wimm.Secundatives.UnitTests.Extensions
             var expected = new Maybe<int>(42);
             var func = new Mock<Func<Maybe<int>>>();
 
-            Assert.Equal(
-                expected,
-                expected.Or(func.Object));
+            Assert.Equal(expected, expected.Or(func.Object));
 
             func.Verify(f => f.Invoke(), Times.Never);
         }
@@ -64,8 +54,7 @@ namespace wimm.Secundatives.UnitTests.Extensions
         public async Task Or_MaybeFuncTask_NeitherMaybeExists_ReturnsNone()
         {
             Assert.Equal(
-                Maybe<int>.None,
-                await Maybe<int>.None.Or(() => Task.FromResult(Maybe<int>.None)));
+                Maybe<int>.None, await Maybe<int>.None.Or(() => Task.FromResult(Maybe<int>.None)));
         }
 
         [Fact]
@@ -73,9 +62,7 @@ namespace wimm.Secundatives.UnitTests.Extensions
         {
             var expected = new Maybe<int>(42);
 
-            Assert.Equal(
-                expected,
-                await Maybe<int>.None.Or(() => Task.FromResult(expected)));
+            Assert.Equal(expected,  await Maybe<int>.None.Or(() => Task.FromResult(expected)));
         }
 
         [Fact]
@@ -83,9 +70,7 @@ namespace wimm.Secundatives.UnitTests.Extensions
         {
             var expected = new Maybe<int>(42);
 
-            Assert.Equal(
-                expected,
-                await expected.Or(() => Task.FromResult(Maybe<int>.None)));
+            Assert.Equal(expected, await expected.Or(() => Task.FromResult(Maybe<int>.None)));
         }
 
         [Fact]
@@ -93,9 +78,7 @@ namespace wimm.Secundatives.UnitTests.Extensions
         {
             var expected = new Maybe<int>(42);
 
-            Assert.Equal(
-                expected,
-                await expected.Or(() => Task.FromResult(new Maybe<int>(43))));
+            Assert.Equal(expected, await expected.Or(() => Task.FromResult(new Maybe<int>(43))));
         }
 
         [Fact]
@@ -104,9 +87,7 @@ namespace wimm.Secundatives.UnitTests.Extensions
             var expected = new Maybe<int>(42);
             var func = new Mock<Func<Task<Maybe<int>>>>();
 
-            Assert.Equal(
-                expected,
-                await expected.Or(func.Object));
+            Assert.Equal(expected, await expected.Or(func.Object));
 
             func.Verify(f => f.Invoke(), Times.Never);
         }
@@ -115,8 +96,7 @@ namespace wimm.Secundatives.UnitTests.Extensions
         public async Task Or_TaskMaybeFunc_NeitherMaybeExists_ReturnsNone()
         {
             Assert.Equal(
-                Maybe<int>.None,
-                await Task.FromResult(Maybe<int>.None).Or(() => Maybe<int>.None));
+                Maybe<int>.None, await Task.FromResult(Maybe<int>.None).Or(() => Maybe<int>.None));
         }
 
         [Fact]
@@ -124,9 +104,7 @@ namespace wimm.Secundatives.UnitTests.Extensions
         {
             var expected = new Maybe<int>(42);
 
-            Assert.Equal(
-                expected,
-                await Task.FromResult(Maybe<int>.None).Or(() => expected));
+            Assert.Equal(expected, await Task.FromResult(Maybe<int>.None).Or(() => expected));
         }
 
         [Fact]
@@ -134,9 +112,7 @@ namespace wimm.Secundatives.UnitTests.Extensions
         {
             var expected = new Maybe<int>(42);
 
-            Assert.Equal(
-                expected,
-                await Task.FromResult(expected).Or(() => Maybe<int>.None));
+            Assert.Equal(expected, await Task.FromResult(expected).Or(() => Maybe<int>.None));
         }
 
         [Fact]
@@ -144,9 +120,7 @@ namespace wimm.Secundatives.UnitTests.Extensions
         {
             var expected = new Maybe<int>(42);
 
-            Assert.Equal(
-                expected,
-                await Task.FromResult(expected).Or(() => new Maybe<int>(43)));
+            Assert.Equal(expected, await Task.FromResult(expected).Or(() => new Maybe<int>(43)));
         }
 
         [Fact]
@@ -155,9 +129,7 @@ namespace wimm.Secundatives.UnitTests.Extensions
             var expected = new Maybe<int>(42);
             var func = new Mock<Func<Maybe<int>>>();
 
-            Assert.Equal(
-                expected,
-                await Task.FromResult(expected).Or(func.Object));
+            Assert.Equal(expected, await Task.FromResult(expected).Or(func.Object));
 
             func.Verify(f => f.Invoke(), Times.Never);
         }
@@ -206,9 +178,7 @@ namespace wimm.Secundatives.UnitTests.Extensions
             var expected = new Maybe<int>(42);
             var func = new Mock<Func<Task<Maybe<int>>>>();
 
-            Assert.Equal(
-                expected,
-                await Task.FromResult(expected).Or(func.Object));
+            Assert.Equal(expected,  await Task.FromResult(expected).Or(func.Object));
 
             func.Verify(f => f.Invoke(), Times.Never);
         }

--- a/wimm.Secundatives.UnitTests/Extensions/Or_Test.cs
+++ b/wimm.Secundatives.UnitTests/Extensions/Or_Test.cs
@@ -1,0 +1,216 @@
+﻿using Xunit;
+
+using wimm.Secundatives.Extensions;
+using System.Threading.Tasks;
+using System;
+using Moq;
+
+namespace wimm.Secundatives.UnitTests.Extensions
+{
+    public class Or_Test
+    {
+        [Fact]
+        public void Or_MaybeFunc_NeitherMaybeExists_ReturnsNone()
+        {
+            Assert.Equal(
+                Maybe<int>.None,
+                Maybe<int>.None.Or(() => Maybe<int>.None));
+        }
+
+        [Fact]
+        public void Or_MaybeFunc_SecondMaybeExists_ReturnsSecondMaybe()
+        {
+            var expected = new Maybe<int>(42);
+
+            Assert.Equal(
+                expected,
+                Maybe<int>.None.Or(() => expected));
+        }
+
+        [Fact]
+        public void Or_MaybeFunc_FirstMaybeExists_ReturnsFirstMaybe()
+        {
+            var expected = new Maybe<int>(42);
+
+            Assert.Equal(
+                expected,
+                expected.Or(() => Maybe<int>.None));
+        }
+
+        [Fact]
+        public void Or_MaybeFunc_BothMaybesExists_ReturnsFirstMaybe()
+        {
+            var expected = new Maybe<int>(42);
+
+            Assert.Equal(
+                expected,
+                expected.Or(() => new Maybe<int>(43)));
+        }
+
+        [Fact]
+        public void Or_MaybeFunc_BothMaybesExists_FuncDoesNotRun()
+        {
+            var expected = new Maybe<int>(42);
+            var func = new Mock<Func<Maybe<int>>>();
+
+            Assert.Equal(
+                expected,
+                expected.Or(func.Object));
+
+            func.Verify(f => f.Invoke(), Times.Never);
+        }
+
+        [Fact]
+        public async Task Or_MaybeFuncTask_NeitherMaybeExists_ReturnsNone()
+        {
+            Assert.Equal(
+                Maybe<int>.None,
+                await Maybe<int>.None.Or(() => Task.FromResult(Maybe<int>.None)));
+        }
+
+        [Fact]
+        public async Task OrMaybeFuncTask_SecondMaybeExists_ReturnsSecondMaybe()
+        {
+            var expected = new Maybe<int>(42);
+
+            Assert.Equal(
+                expected,
+                await Maybe<int>.None.Or(() => Task.FromResult(expected)));
+        }
+
+        [Fact]
+        public async Task Or_MaybeFuncTask_FirstMaybeExists_ReturnsFirstMaybe()
+        {
+            var expected = new Maybe<int>(42);
+
+            Assert.Equal(
+                expected,
+                await expected.Or(() => Task.FromResult(Maybe<int>.None)));
+        }
+
+        [Fact]
+        public async Task Or_MaybeFuncTask_BothMaybesExists_ReturnsFirstMaybe()
+        {
+            var expected = new Maybe<int>(42);
+
+            Assert.Equal(
+                expected,
+                await expected.Or(() => Task.FromResult(new Maybe<int>(43))));
+        }
+
+        [Fact]
+        public async Task Or_MaybeFuncTask_BothMaybesExists_FuncDoesNotRun()
+        {
+            var expected = new Maybe<int>(42);
+            var func = new Mock<Func<Task<Maybe<int>>>>();
+
+            Assert.Equal(
+                expected,
+                await expected.Or(func.Object));
+
+            func.Verify(f => f.Invoke(), Times.Never);
+        }
+
+        [Fact]
+        public async Task Or_TaskMaybeFunc_NeitherMaybeExists_ReturnsNone()
+        {
+            Assert.Equal(
+                Maybe<int>.None,
+                await Task.FromResult(Maybe<int>.None).Or(() => Maybe<int>.None));
+        }
+
+        [Fact]
+        public async Task Or_TaskMaybeFunc_SecondMaybeExists_ReturnsSecondMaybe()
+        {
+            var expected = new Maybe<int>(42);
+
+            Assert.Equal(
+                expected,
+                await Task.FromResult(Maybe<int>.None).Or(() => expected));
+        }
+
+        [Fact]
+        public async Task Or_TaskMaybeFunc_FirstMaybeExists_ReturnsFirstMaybe()
+        {
+            var expected = new Maybe<int>(42);
+
+            Assert.Equal(
+                expected,
+                await Task.FromResult(expected).Or(() => Maybe<int>.None));
+        }
+
+        [Fact]
+        public async Task Or_TaskMaybeFunc_BothMaybesExists_ReturnsFirstMaybe()
+        {
+            var expected = new Maybe<int>(42);
+
+            Assert.Equal(
+                expected,
+                await Task.FromResult(expected).Or(() => new Maybe<int>(43)));
+        }
+
+        [Fact]
+        public async Task Or_TaskMaybeFunc_BothMaybesExists_FuncDoesNotRun()
+        {
+            var expected = new Maybe<int>(42);
+            var func = new Mock<Func<Maybe<int>>>();
+
+            Assert.Equal(
+                expected,
+                await Task.FromResult(expected).Or(func.Object));
+
+            func.Verify(f => f.Invoke(), Times.Never);
+        }
+
+        [Fact]
+        public async Task Or_TaskMaybeFuncTask_NeitherMaybeExists_ReturnsNone()
+        {
+            Assert.Equal(
+                Maybe<int>.None,
+                await Task.FromResult(Maybe<int>.None).Or(() => Task.FromResult(Maybe<int>.None)));
+        }
+
+        [Fact]
+        public async Task Or_TaskMaybeFuncTask_SecondMaybeExists_ReturnsSecondMaybe()
+        {
+            var expected = new Maybe<int>(42);
+
+            Assert.Equal(
+                expected,
+                await Task.FromResult(Maybe<int>.None).Or(() => Task.FromResult(expected)));
+        }
+
+        [Fact]
+        public async Task Or_TaskMaybeFuncTask_FirstMaybeExists_ReturnsFirstMaybe()
+        {
+            var expected = new Maybe<int>(42);
+
+            Assert.Equal(
+                expected,
+                await Task.FromResult(expected).Or(() => Task.FromResult(Maybe<int>.None)));
+        }
+
+        [Fact]
+        public async Task Or_TaskMaybeFuncTask_BothMaybesExists_ReturnsFirstMaybe()
+        {
+            var expected = new Maybe<int>(42);
+
+            Assert.Equal(
+                expected,
+                await Task.FromResult(expected).Or(() => Task.FromResult(new Maybe<int>(43))));
+        }
+
+        [Fact]
+        public async Task Or_TaskMaybeFuncTask_BothMaybesExists_FuncDoesNotRun()
+        {
+            var expected = new Maybe<int>(42);
+            var func = new Mock<Func<Task<Maybe<int>>>>();
+
+            Assert.Equal(
+                expected,
+                await Task.FromResult(expected).Or(func.Object));
+
+            func.Verify(f => f.Invoke(), Times.Never);
+        }
+    }
+}

--- a/wimm.Secundatives.UnitTests/wimm.Secundatives.UnitTests.csproj
+++ b/wimm.Secundatives.UnitTests/wimm.Secundatives.UnitTests.csproj
@@ -22,6 +22,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+    <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />

--- a/wimm.Secundatives/Extensions/MaybeExtensions.cs
+++ b/wimm.Secundatives/Extensions/MaybeExtensions.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using wimm.Secundatives.Exceptions;
 
@@ -153,6 +150,96 @@ namespace wimm.Secundatives.Extensions
         public static async Task<Maybe<T>> AsMaybe<T>(this Task<T?> value) where T : struct
         {
             return (await value).AsMaybe();
+        }
+
+        /// <summary>
+        /// Builds a chain of <see cref="Maybe{T}"/> expressions that returns the first
+        /// <see cref="Maybe{T}"/> that exists.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The value type of of the <see cref="Maybe{T}"/> expressions.
+        /// </typeparam>
+        /// <param name="a">The first <see cref="Maybe{T}"/> to inspect for existance.</param>
+        /// <param name="b">
+        /// A <see cref="Func{T}"/> returning the <see cref="Maybe{T}"/> to return if
+        /// <paramref name="a"/> does not exist.
+        /// </param>
+        /// <returns>
+        /// <paramref name="a"/> if it exists, otherwise the result of evaluating
+        /// <paramref name="b"/>. NOTE: It's possible that the result of evaluating
+        /// <paramref name="b"/> will not exist.
+        /// </returns>
+        public static Maybe<T> Or<T>(this Maybe<T> a, Func<Maybe<T>> b) =>
+            a.Exists ? a : b();
+
+        /// <summary>
+        /// Builds a <see cref="Task{T}"/> that executes a chain of <see cref="Maybe{T}"/>
+        /// expressions returning the first <see cref="Maybe{T}"/> that exists.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The value type of of the <see cref="Maybe{T}"/> expressions.
+        /// </typeparam>
+        /// <param name="a">The first <see cref="Maybe{T}"/> to inspect for existance.</param>
+        /// <param name="b">
+        /// A <see cref="Func{T}"/> returning a <see cref="Task{T}"/> that produces the
+        /// <see cref="Maybe{T}"/> to return if <paramref name="a"/> does not exist.
+        /// </param>
+        /// <returns><paramref name="a"/> if it exists, otherwise the result of evaluating
+        /// <paramref name="b"/>. NOTE: It's possible that the result of evaluating
+        /// <paramref name="b"/> will not exist.
+        /// </returns>
+        public static Task<Maybe<T>> Or<T>(this Maybe<T> a, Func<Task<Maybe<T>>> b) =>
+            a.Exists ? Task.FromResult(a) : b();
+
+        /// <summary>
+        /// Builds a <see cref="Task{T}"/> that executes a chain of <see cref="Maybe{T}"/>
+        /// expressions returning the first <see cref="Maybe{T}"/> that exists.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The value type of of the <see cref="Maybe{T}"/> expressions.
+        /// </typeparam>
+        /// <param name="a">
+        /// A <see cref="Task{T}"/> producing the first <see cref="Maybe{T}"/> to inspect for
+        /// existance.
+        /// </param>
+        /// <param name="b">
+        /// A <see cref="Func{T}"/> returning the <see cref="Maybe{T}"/> to return if the result of
+        /// evaluationg <paramref name="a"/> does not exist.
+        /// </param>
+        /// <returns>The result of evaluating <paramref name="a"/> if it exists, otherwise the
+        /// result of evaluating <paramref name="b"/>. NOTE: It's possible that the result of
+        /// evaluating <paramref name="b"/> will not exist.
+        /// </returns>
+        public static async Task<Maybe<T>> Or<T>(this Task<Maybe<T>> a, Func<Maybe<T>> b)
+        {
+            var first = await a;
+            return first.Exists ? first : b();
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Task{T}"/> that executes a chain of <see cref="Maybe{T}"/>
+        /// expressions returning the first <see cref="Maybe{T}"/> that exists.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The value type of of the <see cref="Maybe{T}"/> expressions.
+        /// </typeparam>
+        /// <param name="a">
+        /// A <see cref="Task{T}"/> producing the first <see cref="Maybe{T}"/> to inspect for
+        /// existance.
+        /// </param>
+        /// <param name="b">
+        /// A <see cref="Func{T}"/> returning a <see cref="Task{T}"/> to produce the
+        /// <see cref="Maybe{T}"/> to return if the result of evaluationg <paramref name="a"/> does
+        /// not exist.
+        /// </param>
+        /// <returns>The result of evaluating <paramref name="a"/> if it exists, otherwise the
+        /// result of evaluating <paramref name="b"/>. NOTE: It's possible that the result of
+        /// evaluating <paramref name="b"/> will not exist.
+        /// </returns>
+        public static async Task<Maybe<T>> Or<T>(this Task<Maybe<T>> a, Func<Task<Maybe<T>>> b)
+        {
+            var first = await a;
+            return first.Exists ? first : await b();
         }
     }
 }

--- a/wimm.Secundatives/Extensions/MaybeExtensions.cs
+++ b/wimm.Secundatives/Extensions/MaybeExtensions.cs
@@ -159,18 +159,18 @@ namespace wimm.Secundatives.Extensions
         /// <typeparam name="T">
         /// The value type of of the <see cref="Maybe{T}"/> expressions.
         /// </typeparam>
-        /// <param name="a">The first <see cref="Maybe{T}"/> to inspect for existance.</param>
-        /// <param name="b">
+        /// <param name="primary">The first <see cref="Maybe{T}"/> to inspect for existance.</param>
+        /// <param name="alternate">
         /// A <see cref="Func{T}"/> returning the <see cref="Maybe{T}"/> to return if
-        /// <paramref name="a"/> does not exist.
+        /// <paramref name="primary"/> does not exist.
         /// </param>
         /// <returns>
-        /// <paramref name="a"/> if it exists, otherwise the result of evaluating
-        /// <paramref name="b"/>. NOTE: It's possible that the result of evaluating
-        /// <paramref name="b"/> will not exist.
+        /// <paramref name="primary"/> if it exists, otherwise the result of evaluating
+        /// <paramref name="alternate"/>. NOTE: It's possible that the result of evaluating
+        /// <paramref name="alternate"/> will not exist.
         /// </returns>
-        public static Maybe<T> Or<T>(this Maybe<T> a, Func<Maybe<T>> b) =>
-            a.Exists ? a : b();
+        public static Maybe<T> Or<T>(this Maybe<T> primary, Func<Maybe<T>> alternate) =>
+            primary.Exists ? primary : alternate();
 
         /// <summary>
         /// Builds a <see cref="Task{T}"/> that executes a chain of <see cref="Maybe{T}"/>
@@ -179,17 +179,17 @@ namespace wimm.Secundatives.Extensions
         /// <typeparam name="T">
         /// The value type of of the <see cref="Maybe{T}"/> expressions.
         /// </typeparam>
-        /// <param name="a">The first <see cref="Maybe{T}"/> to inspect for existance.</param>
-        /// <param name="b">
+        /// <param name="primary">The first <see cref="Maybe{T}"/> to inspect for existance.</param>
+        /// <param name="alternate">
         /// A <see cref="Func{T}"/> returning a <see cref="Task{T}"/> that produces the
-        /// <see cref="Maybe{T}"/> to return if <paramref name="a"/> does not exist.
+        /// <see cref="Maybe{T}"/> to return if <paramref name="primary"/> does not exist.
         /// </param>
-        /// <returns><paramref name="a"/> if it exists, otherwise the result of evaluating
-        /// <paramref name="b"/>. NOTE: It's possible that the result of evaluating
-        /// <paramref name="b"/> will not exist.
+        /// <returns><paramref name="primary"/> if it exists, otherwise the result of evaluating
+        /// <paramref name="alternate"/>. NOTE: It's possible that the result of evaluating
+        /// <paramref name="alternate"/> will not exist.
         /// </returns>
-        public static Task<Maybe<T>> Or<T>(this Maybe<T> a, Func<Task<Maybe<T>>> b) =>
-            a.Exists ? Task.FromResult(a) : b();
+        public static async Task<Maybe<T>> Or<T>(this Maybe<T> primary, Func<Task<Maybe<T>>> alternate) =>
+            primary.Exists ? primary : await alternate();
 
         /// <summary>
         /// Builds a <see cref="Task{T}"/> that executes a chain of <see cref="Maybe{T}"/>
@@ -198,23 +198,20 @@ namespace wimm.Secundatives.Extensions
         /// <typeparam name="T">
         /// The value type of of the <see cref="Maybe{T}"/> expressions.
         /// </typeparam>
-        /// <param name="a">
+        /// <param name="primary">
         /// A <see cref="Task{T}"/> producing the first <see cref="Maybe{T}"/> to inspect for
         /// existance.
         /// </param>
-        /// <param name="b">
+        /// <param name="alternate">
         /// A <see cref="Func{T}"/> returning the <see cref="Maybe{T}"/> to return if the result of
-        /// evaluationg <paramref name="a"/> does not exist.
+        /// evaluationg <paramref name="primary"/> does not exist.
         /// </param>
-        /// <returns>The result of evaluating <paramref name="a"/> if it exists, otherwise the
-        /// result of evaluating <paramref name="b"/>. NOTE: It's possible that the result of
-        /// evaluating <paramref name="b"/> will not exist.
+        /// <returns>The result of evaluating <paramref name="primary"/> if it exists, otherwise the
+        /// result of evaluating <paramref name="alternate"/>. NOTE: It's possible that the result of
+        /// evaluating <paramref name="alternate"/> will not exist.
         /// </returns>
-        public static async Task<Maybe<T>> Or<T>(this Task<Maybe<T>> a, Func<Maybe<T>> b)
-        {
-            var first = await a;
-            return first.Exists ? first : b();
-        }
+        public static async Task<Maybe<T>> Or<T>(this Task<Maybe<T>> primary, Func<Maybe<T>> alternate) =>
+            (await primary).Or(alternate);
 
         /// <summary>
         /// Builds a <see cref="Task{T}"/> that executes a chain of <see cref="Maybe{T}"/>
@@ -223,23 +220,20 @@ namespace wimm.Secundatives.Extensions
         /// <typeparam name="T">
         /// The value type of of the <see cref="Maybe{T}"/> expressions.
         /// </typeparam>
-        /// <param name="a">
+        /// <param name="primary">
         /// A <see cref="Task{T}"/> producing the first <see cref="Maybe{T}"/> to inspect for
         /// existance.
         /// </param>
-        /// <param name="b">
+        /// <param name="alternate">
         /// A <see cref="Func{T}"/> returning a <see cref="Task{T}"/> to produce the
-        /// <see cref="Maybe{T}"/> to return if the result of evaluationg <paramref name="a"/> does
+        /// <see cref="Maybe{T}"/> to return if the result of evaluationg <paramref name="primary"/> does
         /// not exist.
         /// </param>
-        /// <returns>The result of evaluating <paramref name="a"/> if it exists, otherwise the
-        /// result of evaluating <paramref name="b"/>. NOTE: It's possible that the result of
-        /// evaluating <paramref name="b"/> will not exist.
+        /// <returns>The result of evaluating <paramref name="primary"/> if it exists, otherwise the
+        /// result of evaluating <paramref name="alternate"/>. NOTE: It's possible that the result of
+        /// evaluating <paramref name="alternate"/> will not exist.
         /// </returns>
-        public static async Task<Maybe<T>> Or<T>(this Task<Maybe<T>> a, Func<Task<Maybe<T>>> b)
-        {
-            var first = await a;
-            return first.Exists ? first : await b();
-        }
+        public static async Task<Maybe<T>> Or<T>(this Task<Maybe<T>> primary, Func<Task<Maybe<T>>> alternate) =>
+            await (await primary).Or(alternate);
     }
 }


### PR DESCRIPTION
Implements .Or extension methods on Maybe<T> and Task<Maybe<T>> to
support chaining an expression that resolves to a Maybe<T> with a second
expression to be evaluated and returned if the target expression
produces Maybe<T>.None.