### PR TITLE
Feature/result mapping

### DIFF
--- a/wimm.Secundatives.UnitTests/Extensions/Expect_Test.cs
+++ b/wimm.Secundatives.UnitTests/Extensions/Expect_Test.cs
@@ -86,9 +86,9 @@ namespace wimm.Secundatives.UnitTests.Extensions
         public async Task ExpectTaskMessage_Value_ThrowsWithMessage()
         {
             var underTest = Task.FromResult(new Maybe<int>(10));
-            var ex = await Assert.ThrowsAsync<ExpectException>(() => underTest.Expect(_message));
+            var ex = await underTest.Expect(_message);
 
-            Assert.Equal(_message, ex.Message);
+            Assert.Equal(10, ex);
         }
 
 

--- a/wimm.Secundatives.UnitTests/Extensions/Expect_Test.cs
+++ b/wimm.Secundatives.UnitTests/Extensions/Expect_Test.cs
@@ -82,6 +82,16 @@ namespace wimm.Secundatives.UnitTests.Extensions
             Assert.Equal(_message, ex.Message);
         }
 
+        [Fact]
+        public async Task ExpectTaskMessage_Value_ThrowsWithMessage()
+        {
+            var underTest = Task.FromResult(new Maybe<int>(10));
+            var ex = await Assert.ThrowsAsync<ExpectException>(() => underTest.Expect(_message));
+
+            Assert.Equal(_message, ex.Message);
+        }
+
+
 
     }
 }

--- a/wimm.Secundatives.UnitTests/Extensions/Expect_Test.cs
+++ b/wimm.Secundatives.UnitTests/Extensions/Expect_Test.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using wimm.Secundatives.Exceptions;
 using wimm.Secundatives.Extensions;
@@ -18,14 +15,14 @@ namespace wimm.Secundatives.UnitTests.Extensions
         public void ExpectMessage_NullMessage_Throws()
         {
             var underTest = new Maybe<string>(_valid);
-            Assert.Throws<ArgumentNullException>("message",() => underTest.Expect(null));
+            Assert.Throws<ArgumentNullException>("message", () => underTest.Expect(null));
         }
 
         [Fact]
         public void ExpectMessage_WhiteSpaceMessage_Throws()
         {
             var underTest = new Maybe<string>(_valid);
-            Assert.Throws<ArgumentException>("message",() => underTest.Expect(" \t\r\n"));
+            Assert.Throws<ArgumentException>("message", () => underTest.Expect(" \t\r\n"));
         }
 
 
@@ -83,7 +80,7 @@ namespace wimm.Secundatives.UnitTests.Extensions
         }
 
         [Fact]
-        public async Task ExpectTaskMessage_Value_ThrowsWithMessage()
+        public async Task ExpectTaskMessage_Value_ReturnsValue()
         {
             var underTest = Task.FromResult(new Maybe<int>(10));
             var ex = await underTest.Expect(_message);

--- a/wimm.Secundatives.UnitTests/Extensions/Expect_Test.cs
+++ b/wimm.Secundatives.UnitTests/Extensions/Expect_Test.cs
@@ -83,9 +83,7 @@ namespace wimm.Secundatives.UnitTests.Extensions
         public async Task ExpectTaskMessage_Value_ReturnsValue()
         {
             var underTest = Task.FromResult(new Maybe<int>(10));
-            var ex = await underTest.Expect(_message);
-
-            Assert.Equal(10, ex);
+            Assert.Equal(10, await underTest.Expect(_message));
         }
 
 

--- a/wimm.Secundatives.UnitTests/Extensions/OkOr_Test.cs
+++ b/wimm.Secundatives.UnitTests/Extensions/OkOr_Test.cs
@@ -97,7 +97,26 @@ namespace wimm.Secundatives.UnitTests.Extensions
             var result = await underTest.OkOr(TestingEnum.BadThingsHappened);
 
             Assert.Equal("doot", result.Value);
+        }
 
+        [Fact]
+        public async Task OkOrErrorTaskValue_ResultMemberIsNone_ReturnsErrorValuedResult()
+        {
+            var underTest = Task.FromResult(Maybe<Result<string, TestingEnum>>.None);
+            var result = await underTest.OkOr(TestingEnum.BadThingsHappened);
+            
+            Assert.Equal(TestingEnum.BadThingsHappened, result.Error);
+
+        }
+
+        [Fact]
+        public async Task OkOrErrorTaskFunc_ResultMemberExists_ReturnsInternalResult()
+        {
+            var input = new Result<string, TestingEnum>("doot");
+            var underTest = Task.FromResult(new Maybe<Result<string, TestingEnum>>(input));
+            var result = await underTest.OkOr(() => TestingEnum.BadThingsHappened);
+
+            Assert.Equal("doot", result.Value);
         }
 
         [Fact]

--- a/wimm.Secundatives.UnitTests/Extensions/OkOr_Test.cs
+++ b/wimm.Secundatives.UnitTests/Extensions/OkOr_Test.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace wimm.Secundatives.UnitTests.Extensions
 {
-    public class OkOr_Tests
+    public class OkOr_Test
     {
         [Fact]
         public void OkOrFunc_Value_ReturnsResultWithValue()
@@ -89,6 +89,24 @@ namespace wimm.Secundatives.UnitTests.Extensions
             Assert.Equal(TestingEnum.BadThingsHappened, result.Error);
         }
 
+        [Fact] 
+        public async Task OkOrErrorTaskValue_ResultMemberExists_ReturnsInternalResult()
+        {
+            var input = new Result<string, TestingEnum>("doot");
+            var underTest = Task.FromResult(new Maybe<Result<string,TestingEnum>>(input));
+            var result = await underTest.OkOr(TestingEnum.BadThingsHappened);
+
+            Assert.Equal("doot", result.Value);
+
+        }
+
+        [Fact]
+        public async Task OkOrErrorTaskFunc_ResultMemberIsNone_ReturnsInternalResult()
+        {
+            var underTest = Task.FromResult(Maybe<Result<string, TestingEnum>>.None);
+            var result = await underTest.OkOr(() => TestingEnum.BadThingsHappened);
+            Assert.Equal(TestingEnum.BadThingsHappened, result.Error);
+        }
 
 
         public enum TestingEnum

--- a/wimm.Secundatives.UnitTests/Extensions/ResultMapping_Test.cs
+++ b/wimm.Secundatives.UnitTests/Extensions/ResultMapping_Test.cs
@@ -30,7 +30,7 @@ namespace wimm.Secundatives.UnitTests.Extensions
         public async Task MapResult_IsSuccessAndFuncReturnsTask_ReturnsResultOfFunc()
         {
             var underTest = ConstructWith("doot");
-            var res = await underTest.Map(async x => await Task.FromResult("skeleton"));
+            var res = await underTest.Map(x => Task.FromResult("skeleton"));
 
             Assert.Equal("skeleton", res.Value);
         }
@@ -39,7 +39,7 @@ namespace wimm.Secundatives.UnitTests.Extensions
         public async Task MapResult_IsErrorAndFuncReturnsTask_ReturnsError()
         {
             var underTest = new Result<string, TestError>(TestError.Sadness);
-            var res = await underTest.Map(async x => await Task.FromResult("skeleton"));
+            var res = await underTest.Map(x => Task.FromResult("skeleton"));
 
             Assert.True(res.IsError);
             Assert.Equal(TestError.Sadness, res.Error);
@@ -54,7 +54,6 @@ namespace wimm.Secundatives.UnitTests.Extensions
             Assert.Equal("skeleton", res.Value);
         }
 
-        //
         [Fact]
         public async Task MapTaskResult_IsErrorAndFuncReturnsValue_ReturnsError()
         {
@@ -70,7 +69,7 @@ namespace wimm.Secundatives.UnitTests.Extensions
         public async Task MapTaskResult_IsSuccessAndFuncReturnsTask_ReturnsResultOfFunc()
         {
             var underTest = Task.FromResult(ConstructWith("doot"));
-            var res = await underTest.Map(async x => await Task.FromResult("skeleton"));
+            var res = await underTest.Map(x => Task.FromResult("skeleton"));
 
             Assert.Equal("skeleton", res.Value);
         }
@@ -79,18 +78,17 @@ namespace wimm.Secundatives.UnitTests.Extensions
         public async Task MapTaskResult_IsErrorAndFuncReturnsTask_ReturnsError()
         {
             var underTest = Task.FromResult(new Result<string, TestError>(TestError.Sadness));
-            var res = await underTest.Map(async x => await Task.FromResult("skeleton"));
+            var res = await underTest.Map(x => Task.FromResult("skeleton"));
 
             Assert.True(res.IsError);
             Assert.Equal(TestError.Sadness, res.Error);
         }
 
-        //
         [Fact]
         public async Task MapResult_IsSuccessAndFuncReturnsTaskResult_ReturnsResultOfFunc()
         {
             var underTest = ConstructWith("doot");
-            var res = await underTest.Map(async x => await Task.FromResult(ConstructWith("skeleton")));
+            var res = await underTest.Map(x => Task.FromResult(ConstructWith("skeleton")));
 
             Assert.Equal("skeleton", res.Value);
         }
@@ -99,7 +97,7 @@ namespace wimm.Secundatives.UnitTests.Extensions
         public async Task MapResult_IsErrorAndFuncReturnsTaskResult_ReturnsError()
         {
             var underTest = new Result<string, TestError>(TestError.Sadness);
-            var res = await underTest.Map(async x => await Task.FromResult(ConstructWith("skeleton")));
+            var res = await underTest.Map(x => Task.FromResult(ConstructWith("skeleton")));
 
             Assert.True(res.IsError);
             Assert.Equal(TestError.Sadness, res.Error);
@@ -110,7 +108,7 @@ namespace wimm.Secundatives.UnitTests.Extensions
         public async Task MapTaskResult_IsSuccessAndFuncReturnsTaskResult_ReturnsResultOfFunc()
         {
             var underTest = Task.FromResult(ConstructWith("doot"));
-            var res = await underTest.Map(async x => await Task.FromResult(ConstructWith("skeleton")));
+            var res = await underTest.Map(x => Task.FromResult(ConstructWith("skeleton")));
 
             Assert.Equal("skeleton", res.Value);
         }
@@ -119,7 +117,7 @@ namespace wimm.Secundatives.UnitTests.Extensions
         public async Task MapTaskResult_IsErrorAndFuncReturnsTaskResult_ReturnsError()
         {
             var underTest = Task.FromResult(new Result<string, TestError>(TestError.Sadness));
-            var res = await underTest.Map(async x => await Task.FromResult(ConstructWith("skeleton")));
+            var res = await underTest.Map(x => Task.FromResult(ConstructWith("skeleton")));
 
             Assert.True(res.IsError);
             Assert.Equal(TestError.Sadness, res.Error);

--- a/wimm.Secundatives.UnitTests/Extensions/ResultMapping_Test.cs
+++ b/wimm.Secundatives.UnitTests/Extensions/ResultMapping_Test.cs
@@ -1,0 +1,186 @@
+﻿using System.Threading.Tasks;
+using Xunit;
+
+namespace wimm.Secundatives.UnitTests.Extensions
+{
+    public class ResultMapping_Test
+    {
+        [Fact]
+        public void MapResult_IsSuccessAndFuncReturnsValue_ReturnsResultOfFunc()
+        {
+            var underTest = ConstructWith("doot");
+            var res = underTest.Map(x => "deet");
+
+            Assert.Equal("deet", res.Value);
+        }
+
+        [Fact]
+        public void MapResult_IsErrorAndFuncReturnsValue_ReturnsError()
+        {
+            var underTest = new Result<string, TestError>(TestError.Sadness);
+
+            var res = underTest.Map(x => "deet");
+
+            Assert.True(res.IsError);
+            Assert.Equal(TestError.Sadness, res.Error);
+
+        }
+
+        [Fact]
+        public async Task MapResult_IsSuccessAndFuncReturnsTask_ReturnsResultOfFunc()
+        {
+            var underTest = ConstructWith("doot");
+            var res = await underTest.Map(async x => await Task.FromResult("skeleton"));
+
+            Assert.Equal("skeleton", res.Value);
+        }
+
+        [Fact]
+        public async Task MapResult_IsErrorAndFuncReturnsTask_ReturnsError()
+        {
+            var underTest = new Result<string, TestError>(TestError.Sadness);
+            var res = await underTest.Map(async x => await Task.FromResult("skeleton"));
+
+            Assert.True(res.IsError);
+            Assert.Equal(TestError.Sadness, res.Error);
+        }
+
+        [Fact]
+        public async Task MapTaskResult_IsSuccessAndFuncReturnsValue_ReturnsResultOfFunc()
+        {
+            var underTest = Task.FromResult(ConstructWith("doot"));
+            var res = await underTest.Map(x => "skeleton");
+
+            Assert.Equal("skeleton", res.Value);
+        }
+
+        //
+        [Fact]
+        public async Task MapTaskResult_IsErrorAndFuncReturnsValue_ReturnsError()
+        {
+            var underTest = Task.FromResult(new Result<string, TestError>(TestError.Sadness));
+            var res = await underTest.Map(x => "skeleton");
+
+            Assert.True(res.IsError);
+            Assert.Equal(TestError.Sadness, res.Error);
+        }
+
+
+        [Fact]
+        public async Task MapTaskResult_IsSuccessAndFuncReturnsTask_ReturnsResultOfFunc()
+        {
+            var underTest = Task.FromResult(ConstructWith("doot"));
+            var res = await underTest.Map(async x => await Task.FromResult("skeleton"));
+
+            Assert.Equal("skeleton", res.Value);
+        }
+
+        [Fact]
+        public async Task MapTaskResult_IsErrorAndFuncReturnsTask_ReturnsError()
+        {
+            var underTest = Task.FromResult(new Result<string, TestError>(TestError.Sadness));
+            var res = await underTest.Map(async x => await Task.FromResult("skeleton"));
+
+            Assert.True(res.IsError);
+            Assert.Equal(TestError.Sadness, res.Error);
+        }
+
+        //
+        [Fact]
+        public async Task MapResult_IsSuccessAndFuncReturnsTaskResult_ReturnsResultOfFunc()
+        {
+            var underTest = ConstructWith("doot");
+            var res = await underTest.Map(async x => await Task.FromResult(ConstructWith("skeleton")));
+
+            Assert.Equal("skeleton", res.Value);
+        }
+
+        [Fact]
+        public async Task MapResult_IsErrorAndFuncReturnsTaskResult_ReturnsError()
+        {
+            var underTest = new Result<string, TestError>(TestError.Sadness);
+            var res = await underTest.Map(async x => await Task.FromResult(ConstructWith("skeleton")));
+
+            Assert.True(res.IsError);
+            Assert.Equal(TestError.Sadness, res.Error);
+        }
+        //
+
+        [Fact]
+        public async Task MapTaskResult_IsSuccessAndFuncReturnsTaskResult_ReturnsResultOfFunc()
+        {
+            var underTest = Task.FromResult(ConstructWith("doot"));
+            var res = await underTest.Map(async x => await Task.FromResult(ConstructWith("skeleton")));
+
+            Assert.Equal("skeleton", res.Value);
+        }
+
+        [Fact]
+        public async Task MapTaskResult_IsErrorAndFuncReturnsTaskResult_ReturnsError()
+        {
+            var underTest = Task.FromResult(new Result<string, TestError>(TestError.Sadness));
+            var res = await underTest.Map(async x => await Task.FromResult(ConstructWith("skeleton")));
+
+            Assert.True(res.IsError);
+            Assert.Equal(TestError.Sadness, res.Error);
+        }
+
+        [Fact]
+        public void MapErrorValue_IsErrorAndFuncReturnsValue_ReturnsResultOfFunc()
+        {
+            var underTest = new Result<string, TestError>(TestError.Sadness);
+            var res = underTest.MapError(x => OtherError.OtherSadness);
+
+            Assert.True(res.IsError);
+            Assert.Equal(OtherError.OtherSadness, res.Error);
+        }
+
+
+        [Fact]
+        public void MapErrorValue_IsSuccessAndFuncReturnsValue_ReturnsValue()
+        {
+            var underTest = ConstructWith("doot");
+            var res = underTest.MapError(x => OtherError.OtherSadness);
+
+            Assert.Equal("doot", res.Value);
+        }
+
+        [Fact]
+        public async Task MapErrorTask_IsErrorAndFuncReturnsValue_ReturnsResultOfFunc()
+        {
+            var underTest = Task.FromResult(new Result<string, TestError>(TestError.Sadness));
+            var res = await underTest.MapError(x => OtherError.OtherSadness);
+
+            Assert.True(res.IsError);
+            Assert.Equal(OtherError.OtherSadness, res.Error);
+        }
+
+
+        [Fact]
+        public async Task MapErrorTask_IsSuccessAndFuncReturnsValue_ReturnsValue()
+        {
+            var underTest = Task.FromResult(ConstructWith("doot"));
+            var res = await underTest.MapError(x => OtherError.OtherSadness);
+
+            Assert.Equal("doot", res.Value);
+        }
+
+
+        private Result<T, TestError> ConstructWith<T>(T value)
+        {
+            return new Result<T, TestError>(value);
+        }
+
+
+        private enum TestError
+        {
+            Sadness
+        }
+
+        private enum OtherError
+        {
+            OtherSadness
+        }
+
+    }
+}

--- a/wimm.Secundatives.UnitTests/Variant_Test.cs
+++ b/wimm.Secundatives.UnitTests/Variant_Test.cs
@@ -74,6 +74,12 @@ namespace wimm.Secundatives.UnitTests
             Assert.True(intVariant.Is<int>());
         }
 
+        [Fact]
+        public void Construct_TwoTypesInSameHeirarchy_ThrowsTypeInitException()
+        {
+            Assert.Throws<TypeInitializationException>(() => new Variant<Base, Derived>(new Base()));
+        }
+
         private Variant<int, string> ConstructString()
         {
             return new Variant<int, string>(_testString);
@@ -83,6 +89,8 @@ namespace wimm.Secundatives.UnitTests
         {
             return new Variant<int, string>(42);
         }
+
+
 
         class Base { }
         class Derived : Base { }

--- a/wimm.Secundatives/Extensions/OkOrExtensions.cs
+++ b/wimm.Secundatives/Extensions/OkOrExtensions.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
+using wimm.Secundatives.Extensions;
 
 namespace wimm.Secundatives
 {
@@ -16,7 +14,7 @@ namespace wimm.Secundatives
         /// </summary>
         /// <typeparam name="T"> The value of the success type </typeparam>
         /// <typeparam name="TError"> The value of the error type created when <paramref name="value"/> contains no value </typeparam>
-        /// <param name="value"> The <paramref name="value"/> whose existence determines whether <see cref="Result{T, TError}"/> </param>
+        /// <param name="value"> The <paramref name="value"/> whose existence determines whether <see cref="Result{T, TError}"/> is a value or an error</param>
         /// <param name="func"> A function returning a <typeparamref name="TError"/> that is executed if <paramref name="value"/> is None</param>
         /// <returns> A <see cref="Result{T, TError}"/> containing the value of <paramref name="value"/> if it contains one, otherwise 
         /// contains the result of executing <paramref name="func"/>
@@ -37,7 +35,7 @@ namespace wimm.Secundatives
         /// </summary>
         /// <typeparam name="T"> The value of the success type </typeparam>
         /// <typeparam name="TError"> The value of the error type created when <paramref name="value"/> contains no value </typeparam>
-        /// <param name="value"> The <paramref name="value"/> whose existence determines whether <see cref="Result{T, TError}"/> </param>
+        /// <param name="value"> The <paramref name="value"/> whose existence determines whether <see cref="Result{T, TError}"/> is a value or an error</param>
         /// <param name="error"> The default value returned if <paramref name="value"/> is None </param>
         /// <returns> A <see cref="Result{T, TError}"/> containing the value of <paramref name="value"/> if it contains one, otherwise 
         /// contains <paramref name="error"/>
@@ -58,7 +56,7 @@ namespace wimm.Secundatives
         /// </summary>
         /// <typeparam name="T"> The value of the success type </typeparam>
         /// <typeparam name="TError"> The value of the error type created when <paramref name="value"/> contains no value </typeparam>
-        /// <param name="value"> The <paramref name="value"/> whose existence determines whether <see cref="Result{T, TError}"/> </param>
+        /// <param name="value"> The <paramref name="value"/> whose existence determines whether <see cref="Result{T, TError}"/> is a value or an error</param>
         /// <param name="error"> The default value returned if <paramref name="value"/> is None </param>
         /// <returns> A <see cref="Result{T, TError}"/> containing the value of <paramref name="value"/> if it contains one, otherwise 
         /// contains <paramref name="error"/>
@@ -76,7 +74,7 @@ namespace wimm.Secundatives
         /// </summary>
         /// <typeparam name="T"> The value of the success type </typeparam>
         /// <typeparam name="TError"> The value of the error type created when <paramref name="value"/> contains no value </typeparam>
-        /// <param name="value"> The <paramref name="value"/> whose existence determines whether <see cref="Result{T, TError}"/> </param>
+        /// <param name="value"> The <paramref name="value"/> whose existence determines whether <see cref="Result{T, TError}"/> is a value or an error</param>
         /// <param name="func"> A function returning a <typeparamref name="TError"/> that is executed if <paramref name="value"/> is None</param>
         /// <returns> A <see cref="Result{T, TError}"/> containing the value of <paramref name="value"/> if it contains one, otherwise 
         /// contains the result of executing <paramref name="func"/>
@@ -87,6 +85,43 @@ namespace wimm.Secundatives
             return v.OkOr(func);
 
         }
+
+
+        /// <summary>
+        /// Collapsing mapping of a  <see cref="Task{T}"/> containing a <see cref="Maybe{T}"/> that may hold a <see cref="Result{T,TErr}"/>
+        /// into a <see cref="Result{T, TError}"/> 
+        /// </summary>
+        /// <typeparam name="T"> The value of the success type </typeparam>
+        /// <typeparam name="TError"> The value of the error type created when <paramref name="value"/> contains no value </typeparam>
+        /// <param name="value"> The <paramref name="value"/> whose existence determines whether <see cref="Result{T, TError}"/> 
+        /// is a the provided result value or a new <see cref="Result{T, TError}"/> created from <paramref name="error"/></param>
+        /// <param name="error"> The default value mappted into a <see cref="Result{T, TError}"/> if <paramref name="value"/> is None </param>
+        /// <returns> A <see cref="Result{T, TError}"/> either contained by <paramref name="value"/> if it exists or created
+        /// from <paramref name="error"/> if it is None</returns>
+        public static async Task<Result<T, TError>> OkOr<T, TError>(this Task<Maybe<Result<T, TError>>> value, TError error)
+        {
+            var res = await value;
+            return res.UnwrapOr(error);
+        }
+
+
+        /// <summary>
+        /// Collapsing mapping of a  <see cref="Task{T}"/> containing a <see cref="Maybe{T}"/> that may hold a <see cref="Result{T,TErr}"/>
+        /// into a <see cref="Result{T, TError}"/> 
+        /// </summary>
+        /// <typeparam name="T"> The value of the success type </typeparam>
+        /// <typeparam name="TError"> The value of the error type created when <paramref name="value"/> contains no value </typeparam>
+        /// <param name="value"> The <paramref name="value"/> whose existence determines whether <see cref="Result{T, TError}"/> 
+        /// is a the provided result value or a new <see cref="Result{T, TError}"/> created from calling <paramref name="func"/></param>
+        /// <param name="func"> A function returning a <typeparamref name="TError"/> that is executed if <paramref name="value"/> is None</param>
+        /// <returns> A <see cref="Result{T, TError}"/> either contained by <paramref name="value"/> if it exists or created
+        /// from the results of calling <paramref name="func"/> if it is None</returns>
+        public static async Task<Result<T, TError>> OkOr<T, TError>(this Task<Maybe<Result<T, TError>>> value, Func<TError> func)
+        {
+            var res = await value;
+            return res.UnwrapOr(func());
+        }
+
 
     }
 }

--- a/wimm.Secundatives/Extensions/ResultMappingExtensions.cs
+++ b/wimm.Secundatives/Extensions/ResultMappingExtensions.cs
@@ -1,0 +1,201 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace wimm.Secundatives
+{
+    public static class ResultMappingExtensions
+    {
+
+        /// <summary>
+        /// Transforms a <see cref="Result{T, TError}"/> into a <see cref="Result{U, TError}"/> by applying a function if the mapped
+        /// <see cref="Result{T, TError}"/> containts a value otherwise by constructing a new <see cref="Result{U, TError}"/> from the 
+        /// <typeparamref name="TError"/> contained within  <paramref name="result"/>
+        /// </summary>
+        /// <typeparam name="T"> The success type of the initial result </typeparam>
+        /// <typeparam name="U"> The type that <paramref name="result"/>'s value will be transformed to by <paramref
+        /// name="func"/></typeparam>
+        /// <typeparam name="TError"> The error type of the results</typeparam>
+        /// <param name="result"> A <see cref="Result{T, TError}"/> whose state determines if a transform occurs </param>
+        /// <param name="func"> The function that will transform <paramref name="result"/>'s <typeparamref name="T"/> if it exists</param>
+        /// <returns> A <see cref="Result{U, TError}"/> containing the result of calling <paramref name="func"/> on the value of <paramref
+        /// name="result"/>
+        /// if it exists. Otherwise returns a <see cref="Result{U, TError}"/> containing the <typeparamref name="TError"/> contained within 
+        /// <paramref name="result"/></returns>
+        public static Result<U, TError> Map<T, U, TError>(this Result<T, TError> result, Func<T, U> func)
+        {
+            if (result.IsValue)
+                return func(result.Value);
+
+            return result.Error;
+        }
+
+
+        /// <summary>
+        /// Transforms a <see cref="Result{T, TError}"/> into a <see cref="Result{U, TError}"/> by applying an async  function if the mapped
+        /// <see cref="Result{T, TError}"/> containts a value otherwise by constructing a new <see cref="Result{U, TError}"/> from the 
+        /// <typeparamref name="TError"/> contained within <paramref name="result"/>
+        /// </summary>
+        /// <typeparam name="T"> The success type of the initial result </typeparam>
+        /// <typeparam name="U"> The type that <paramref name="result"/>'s value will be transformed to by <paramref name="func"/>
+        /// </typeparam>
+        /// <typeparam name="TError"> The error type of the results</typeparam>
+        /// <param name="result"> A <see cref="Result{T, TError}"/> whose state determines if a transform occurs </param>
+        /// <param name="func"> The async function that will transform <paramref name="result"/>'s <typeparamref name="T"/> if it
+        /// exists</param>
+        /// <returns> A <see cref="Result{U, TError}"/> containing the result of awaiting a call to  <paramref name="func"/> on the value of
+        /// <paramref name="result"/>
+        /// if it exists. Otherwise returns a <see cref="Result{U, TError}"/> containing the <typeparamref name="TError"/> contained within 
+        /// <paramref name="result"/></returns>
+        public static async Task<Result<U, TError>> Map<T, U, TError>(this Result<T, TError> result, Func<T, Task<U>> func)
+        {
+            if (result.IsValue)
+                return await func(result.Value);
+
+            return result.Error;
+        }
+
+        /// <summary>
+        /// Asynchronously <see cref="Result{T, TError}"/> into a <see cref="Task{T}"/> <see cref="Result{U, TError}"/> by applying a
+        /// function if the mapped  <see cref="Result{T, TError}"/> containts a value otherwise by constructing a new 
+        /// <see cref="Result{U,TError}"/> from the <typeparamref name="TError"/> contained within <paramref name="result"/>
+        /// </summary>
+        /// <typeparam name="T"> The success type of the initial result </typeparam>
+        /// <typeparam name="U"> The type that <paramref name="result"/>'s value will be transformed to by 
+        /// <paramref name="func"/></typeparam>
+        /// <typeparam name="TError"> The error type of the results</typeparam>
+        /// <param name="result"> A <see cref="Result{T, TError}"/> whose state determines if a transform occurs </param>
+        /// <param name="func"> The function that will transform <paramref name="result"/>'s <typeparamref name="T"/> if it exists</param>
+        /// <returns> a <see cref="Result{U, TError}"/> containing the result of awaiting a call to  <paramref name="func"/> on the value of
+        /// <paramref name="result"/>if it exists. Otherwise returns a <see cref="Result{U, TError}"/> containing the 
+        /// <typeparamref name="TError"/> contained within <paramref name="result"/></returns>
+        public static async Task<Result<U, TError>> Map<T, U, TError>(this Task<Result<T, TError>> result, Func<T, U> func)
+        {
+            var val = await result;
+            return val.Map(func);
+        }
+
+
+        /// <summary>
+        /// Asynchronously transforms a <see cref="Result{T, TError}"/> into a <see cref="Result{U, TError}"/> by applying an async function and collapsing
+        /// the result if the mapped  <see cref="Result{T, TError}"/> containts a value otherwise by constructing a new 
+        /// <see cref="Result{U,TError}"/> from the <typeparamref name="TError"/> contained within <paramref name="result"/>
+        /// </summary>
+        /// <typeparam name="T"> The success type of the initial result </typeparam>
+        /// <typeparam name="U"> The type that <paramref name="result"/>'s value will be transformed to by 
+        /// <paramref name="func"/></typeparam>
+        /// <typeparam name="TError"> The error type of the results</typeparam>
+        /// <param name="result"> A <see cref="Result{T, TError}"/> whose state determines if a transform occurs </param>
+        /// <param name="func"> The async function that will transform <paramref name="result"/>'s <typeparamref name="T"/> if it exists
+        /// into a new <see cref="Result{U, TError}"/></param>
+        /// <returns> A <see cref="Result{U, TError}"/> containing the result of awaiting a call to  <paramref name="func"/> on the value 
+        /// obtained by awaiting <paramref name="result"/> if it exists. Otherwise returns a <see cref="Result{U, TError}"/> containing the
+        /// <typeparamref name="TError"/> contained within  <paramref name="result"/></returns>
+        public static async Task<Result<U, TError>> Map<T, U, TError>(this Task<Result<T, TError>> result, Func<T, Task<U>> func)
+        {
+
+            var res = await result;
+            return await res.Map(func);
+        }
+
+
+        /// <summary>
+        /// Asynchronously transforms a <see cref="Result{T, TError}"/> into a <see cref="Result{U, TError}"/> by applying an async function and collapsing
+        /// the result if the mapped  <see cref="Result{T, TError}"/> containts a value otherwise by constructing a new 
+        /// <see cref="Result{U,TError}"/> from the <typeparamref name="TError"/> contained within <paramref name="result"/>
+        /// </summary>
+        /// <typeparam name="T"> The success type of the initial result </typeparam>
+        /// <typeparam name="U"> The type that <paramref name="result"/>'s value will be transformed to by 
+        /// <paramref name="func"/></typeparam>
+        /// <typeparam name="TError"> The error type of the results</typeparam>
+        /// <param name="result"> A <see cref="Result{T, TError}"/> whose state determines if a transform occurs </param>
+        /// <param name="func"> The async function that will transform <paramref name="result"/>'s <typeparamref name="T"/> if it exists
+        /// into a new <see cref="Result{U, TError}"/></param>
+        /// <returns> A <see cref="Result{U, TError}"/> containing the result of awaiting a call to  <paramref name="func"/> on the value of
+        /// <paramref name="result"/>
+        /// if it exists. Otherwise returns a <see cref="Result{U, TError}"/> containing the <typeparamref name="TError"/> contained within 
+        /// <paramref name="result"/></returns>
+        public static async Task<Result<U, TError>> Map<T, U, TError>(this Result<T, TError> result, Func<T, Task<Result<U, TError>>> func)
+        {
+            if (result.IsValue)
+                return await func(result.Value);
+
+            return result.Error;
+        }
+
+        
+        /// <summary>
+        /// Asynchronously transforms a <see cref="Result{T, TError}"/> into a <see cref="Result{U, TError}"/> by applying an async function and collapsing
+        /// the result if the mapped  <see cref="Result{T, TError}"/> containts a value otherwise by constructing a new 
+        /// <see cref="Result{U,TError}"/> from the <typeparamref name="TError"/> contained within <paramref name="result"/>
+        /// </summary>
+        /// <typeparam name="T"> The success type of the initial result </typeparam>
+        /// <typeparam name="U"> The type that <paramref name="result"/>'s value will be transformed to by 
+        /// <paramref name="func"/></typeparam>
+        /// <typeparam name="TError"> The error type of the results</typeparam>
+        /// <param name="result"> A <see cref="Result{T, TError}"/> whose state determines if a transform occurs </param>
+        /// <param name="func"> The async function that will transform <paramref name="result"/>'s <typeparamref name="T"/> if it exists
+        /// into a new <see cref="Result{U, TError}"/></param>
+        /// <returns> A <see cref="Result{U, TError}"/> containing the result of awaiting a call to  <paramref name="func"/> on the value of
+        /// <paramref name="result"/>
+        /// if it exists. Otherwise returns a <see cref="Result{U, TError}"/> containing the <typeparamref name="TError"/> contained within 
+        /// <paramref name="result"/></returns>
+        public static async Task<Result<U, TError>> Map<T, U, TError>(this Task<Result<T, TError>> result, Func<T, Task<Result<U, TError>>> func)
+        {
+            var res = await result;
+            if (res.IsValue)
+                return await func(res.Value);
+
+            return res.Error;
+        }
+
+
+        /// <summary>
+        /// Transforms a <see cref="Result{T, TError}"/> into a <see cref="Result{T, UError}"/> by applying a function if the mapped 
+        /// <see cref="Result{T, TError}"/> contains a <typeparamref name="UError"/>. Otherwise constructs a new 
+        /// <see cref="Result{T, UError}"/> from the value contained within <paramref name="result"/>
+        /// </summary>
+        /// <typeparam name="T"> The success type of the initial result </typeparam>
+        /// <typeparam name="TError"> The error type of the initial result that will be transformed </typeparam>
+        /// <typeparam name="UError"> The type returned by applying <paramref name="func"/> to the <typeparamref name="TError"/> 
+        /// contained within <paramref name="result"/></typeparam>
+        /// <param name="result"> A <see cref="Result{T, TError}"/> whose state determines if a transform occurs </param>
+        /// <param name="func"> The function that will transform <paramref name="result"/>'s <typeparamref name="TError"/> if it exists
+        /// </param>
+        /// <returns> A <see cref="Result{T, UError}"/> containing the result of calling <paramref name="func"/> on the 
+        /// <typeparamref name="TError"/> of <paramref name="result"/> if it exists. Otherwise returns a <see cref="Result{T, UError}"/> 
+        /// containing the <typeparamref name="T"/> contained within <paramref name="result"/></returns>
+        public static Result<T, UError> MapError<T, TError, UError>(this Result<T, TError> result, Func<TError, UError> func)
+        {
+            if (result.IsError)
+                return func(result.Error);
+
+            return result.Value;
+        }
+
+
+        /// <summary>
+        /// Asynchronously transforms a <see cref="Result{T, TError}"/> into a <see cref="Result{T, UError}"/> by applying a function if the mapped 
+        /// <see cref="Result{T, TError}"/> contains a <typeparamref name="UError"/>. Otherwise constructs a new 
+        /// <see cref="Result{T, UError}"/> from the value contained within <paramref name="result"/>
+        /// </summary>
+        /// <typeparam name="T"> The success type of the initial result </typeparam>
+        /// <typeparam name="TError"> The error type of the initial result that will be transformed </typeparam>
+        /// <typeparam name="UError"> The type returned by applying <paramref name="func"/> to the <typeparamref name="TError"/> 
+        /// contained within <paramref name="result"/></typeparam>
+        /// <param name="result"> A <see cref="Result{T, TError}"/> whose state determines if a transform occurs </param>
+        /// <param name="func"> The function that will transform <paramref name="result"/>'s <typeparamref name="TError"/> if it exists
+        /// </param>
+        /// <returns> A <see cref="Result{T, UError}"/> containing the result of calling <paramref name="func"/> on the 
+        /// <typeparamref name="TError"/> of <paramref name="result"/> if it exists. Otherwise returns a <see cref="Result{T, UError}"/> 
+        /// containing the <typeparamref name="T"/> contained within <paramref name="result"/></returns>
+        public static async Task<Result<T, UError>> MapError<T, TError, UError>(this Task<Result<T, TError>> result, Func<TError, UError> func)
+        {
+            var val = await result;
+            return val.MapError(func);
+        }
+
+    }
+}


### PR DESCRIPTION
+semver:feature

Added result mapping extensions and wrote some of the most boring and hard to name tests ever. Cleaned up some of the other tests where I noticed coverage was missing and expanded OkOr with two methods that collapse Result<Result<T>> so that we don't have to collapse manually. Probably the most boring 97 LOC I've ever written but they let me do this: 

![image](https://user-images.githubusercontent.com/7606469/68098863-95e66f80-fe95-11e9-9d85-952f191e8684.png)



![image](https://user-images.githubusercontent.com/7606469/68098789-2a040700-fe95-11e9-8668-4b4b6d8e0c71.png)
