### PR TITLE
chore: Factor out build-and-release workflow

### DIFF
--- a/.github/actions/build-and-test/action.yml
+++ b/.github/actions/build-and-test/action.yml
@@ -7,10 +7,13 @@ runs:
   steps:
 
     - name: Restore Packages
+      shell: bash
       run: dotnet restore
 
     - name: Build Solution
+      shell: bash
       run: dotnet build --no-restore
 
     - name: Run Unit Tests
+      shell: bash
       run: dotnet test --no-build

--- a/.github/actions/build-and-test/action.yml
+++ b/.github/actions/build-and-test/action.yml
@@ -1,0 +1,16 @@
+name: 'Builds and Test'
+description: 'Builds the library and runs the unit tests'
+
+runs:
+  using: composite
+
+  steps:
+
+    - name: Restore Packages
+      run: dotnet restore
+
+    - name: Build Solution
+      run: dotnet build --no-restore
+
+    - name: Run Unit Tests
+      run: dotnet test --no-build

--- a/.github/actions/build-and-test/action.yml
+++ b/.github/actions/build-and-test/action.yml
@@ -5,7 +5,6 @@ runs:
   using: composite
 
   steps:
-
     - name: Restore Packages
       shell: bash
       run: dotnet restore

--- a/.github/actions/setup-dotnet/action.yml
+++ b/.github/actions/setup-dotnet/action.yml
@@ -1,0 +1,19 @@
+name: 'Setup Dotnet'
+description: 'Sets up the versions of dotnet required by the project'
+
+runs:
+  using: 'composite'
+
+  steps:
+
+    - name: Setup Dotnet 5.0
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 5.0.x
+        include-prerelease: false
+
+    - name: Setup Dotnet 6.0
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 6.0.x
+        include-prerelease: false

--- a/.github/actions/setup-dotnet/action.yml
+++ b/.github/actions/setup-dotnet/action.yml
@@ -5,7 +5,6 @@ runs:
   using: 'composite'
 
   steps:
-
     - name: Setup Dotnet 5.0
       uses: actions/setup-dotnet@v1
       with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,7 +7,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-
       - name: Checkout Code
         uses: actions/checkout@v2
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,11 +1,9 @@
-name: Continuous Integration
-
 on:
-  pull_request:
-    branches: [master]
+  workflow_call:
 
 jobs:
-  build-and-test:
+  build_and_test:
+    name: Build and Test
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-
       - name: Checkout Code
         uses: actions/checkout@v2
 

--- a/wimm.Secundatives.UnitTests/wimm.Secundatives.UnitTests.csproj
+++ b/wimm.Secundatives.UnitTests/wimm.Secundatives.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/wimm.Secundatives/wimm.Secundatives.csproj
+++ b/wimm.Secundatives/wimm.Secundatives.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
     <Description>A collection of types slightly more advanced than primitives.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors>Thomas Showers, Chris Nantau, Secundatives Contributors</Authors>
     <Company>wareismymind</Company>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/wareismymind/Secundatives</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/wareismymind/Secundatives</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/wareismymind/secundatives</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/wareismymind/secundatives</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <IncludeSymbols>true</IncludeSymbols>
   </PropertyGroup>


### PR DESCRIPTION
Creates a build-and-test workflow that can be used by the CI workflow as well as by the coming-soon release-please workflow.

Since GitHub requires an @<ref> suffix even when referencing reusable workflows in the source repository this PR can't update the CI workflow to use it. Instead the job in the CI workflow is defined identically to the reusable workflow to prove it works; and will be updated to use the reusable workflow in another PR after the reusable workflow exists in a stable ref.